### PR TITLE
CLIENT-6116 | Fix mute does not work right after changing input device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+1.7.4 (In Progress)
+====================
+
+Bug Fixes
+---------
+
+* Fixed a bug where changing the input device then later calling `Connection.mute()` will not work.
+
+
 1.7.3 (May 16, 2019)
 ====================
 

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -317,6 +317,11 @@ PeerConnection.prototype._setInputTracksForUnifiedPlan = function(shouldClone, n
   }
 
   const localStream = this.stream;
+  const getStreamPromise = () => {
+    // Apply mute settings to new input track
+    this.mute(this.isMuted);
+    return Promise.resolve(this.stream);
+  };
 
   if (!localStream) {
     // We can't use MediaStream.clone() here because it stopped copying over tracks
@@ -333,14 +338,13 @@ PeerConnection.prototype._setInputTracksForUnifiedPlan = function(shouldClone, n
       this._sender = this.version.pc.getSenders()[0];
     }
 
-    this._sender.replaceTrack(newStream.getAudioTracks()[0]);
-    this._updateInputStreamSource(newStream);
+    return this._sender.replaceTrack(newStream.getAudioTracks()[0]).then(() => {
+      this._updateInputStreamSource(newStream);
+      return getStreamPromise();
+    });
   }
 
-  // Apply mute settings to new input track
-  this.mute(this.isMuted);
-
-  return Promise.resolve(this.stream);
+  return getStreamPromise();
 };
 
 PeerConnection.prototype._onInputDevicesChanged = function() {

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -213,6 +213,38 @@ describe('PeerConnection', () => {
     });
   });
 
+  context('PeerConnection.prototype._setInputTracksForUnifiedPlan', () => {
+    const METHOD = PeerConnection.prototype._setInputTracksForUnifiedPlan;
+    const STREAM = { id: 1 };
+
+    let context = null;
+    let toTest = null;
+
+    beforeEach(() => {
+      context = {
+        stream: STREAM,
+        mute: sinon.stub(),
+        _sender: {}
+      };
+      toTest = METHOD.bind(context);
+    });
+
+    it('Should replace tracks before returning the new stream', done => {
+      const replaceTrackCb = sinon.stub();
+      context._updateInputStreamSource = sinon.stub();
+      context._sender.replaceTrack = () => ({ then: (cb) => {
+        replaceTrackCb();
+        return cb();
+      }})
+
+      toTest(false, { getAudioTracks: () => ['foo'] }).then((result) => {
+        assert(context._updateInputStreamSource.calledOnce);
+        assert(replaceTrackCb.calledOnce);
+        assert.strictEqual(result.id, STREAM.id);
+      }).then(done).catch(done);
+    });
+  });
+
   context('PeerConnection.prototype.close', () => {
     const METHOD = PeerConnection.prototype.close;
 


### PR DESCRIPTION
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6116](https://issues.corp.twilio.com/browse/CLIENT-6116)

### Description

Changing input device and calling mute right after connection, will not mute the device. This happens because we don't wait for replaceTracks to return. This PR will address that.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
