### PR TITLE
CLIENT-6145 CLIENT-5873 | Restart ICE when PeerConnection is disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 1.7.4 (In Progress)
 ====================
 
+Improvements
+------------
+
+* ICE Connections will now attempt to reconnect when they transition to the `failed` state, rather
+  than immediately disconnecting.
+
 Bug Fixes
 ---------
 

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -391,6 +391,8 @@ class Connection extends EventEmitter {
     this.on('disconnect', () => {
       this._cleanupEventListeners();
     });
+
+    this._monitorIceConnection();
   }
 
   /**
@@ -957,6 +959,20 @@ class Connection extends EventEmitter {
     if (!wasRemote) {
       this._publisher.info('connection', 'disconnected-by-local', null, this);
     }
+  }
+
+  /**
+   * Monitors and restarts ICE for the current {@link Connection}
+   */
+  private _monitorIceConnection(): void {
+    const reconnectIce = () => this.mediaStream.iceRestart().then(listen, listen);
+
+    const listen = () => this._monitor.once('disconnect', () => {
+      this._log.warn('ICE Connection disconnected.');
+      reconnectIce();
+    });
+
+    listen();
   }
 
   /**

--- a/lib/twilio/eventpublisher.js
+++ b/lib/twilio/eventpublisher.js
@@ -237,6 +237,8 @@ function formatMetric(sample) {
     packets_lost: sample.packetsLost,
     packets_lost_fraction: sample.packetsLostFraction &&
     (Math.round(sample.packetsLostFraction * 100) / 100),
+    bytes_received: sample.bytesReceived,
+    bytes_sent: sample.bytesSent,
     audio_codec: sample.codecName,
     audio_level_in: sample.audioInputLevel,
     audio_level_out: sample.audioOutputLevel,

--- a/lib/twilio/rtc/monitor.js
+++ b/lib/twilio/rtc/monitor.js
@@ -3,9 +3,6 @@ const getStatistics = require('./stats');
 const inherits = require('util').inherits;
 const Mos = require('./mos');
 
-// Inactivity wait duration before we raise ice 'disconnect'
-const ICE_DISCONNECT_THRESHOLD = 3000;
-
 // How many samples we use when testing metric thresholds
 const SAMPLE_COUNT_METRICS = 5;
 
@@ -31,6 +28,8 @@ const WARNING_TIMEOUT = 5 * 1000;
  *   the specified number of consequent samples.
  */
 const DEFAULT_THRESHOLDS = {
+  bytesReceived: { maxDuration: 3 },
+  bytesSent: { maxDuration: 3 },
   packetsLostFraction: { max: 1 },
   jitter: { max: 30 },
   rtt: { max: 400 },
@@ -58,7 +57,6 @@ function RTCMonitor(options) {
   Object.defineProperties(this, {
     _activeWarnings: { value: new Map() },
     _currentStreaks: { value: new Map() },
-    _lastDisconnect: { value: 0, writable: true },
     _peerConnection: { value: options.peerConnection, writable: true },
     _sampleBuffer: { value: [] },
     _sampleInterval: { value: null, writable: true },
@@ -83,10 +81,14 @@ inherits(RTCMonitor, EventEmitter);
  * @returns {Promise<RTCSample>}
  */
 RTCMonitor.createSample = function createSample(stats, previousSample) {
+  const previousBytesSent = previousSample && previousSample.totals.bytesSent || 0;
+  const previousBytesReceived = previousSample && previousSample.totals.bytesReceived || 0;
   const previousPacketsSent = previousSample && previousSample.totals.packetsSent || 0;
   const previousPacketsReceived = previousSample && previousSample.totals.packetsReceived || 0;
   const previousPacketsLost = previousSample && previousSample.totals.packetsLost || 0;
 
+  const currentBytesSent = stats.bytesSent - previousBytesSent;
+  const currentBytesReceived = stats.bytesReceived - previousBytesReceived;
   const currentPacketsSent = stats.packetsSent - previousPacketsSent;
   const currentPacketsReceived = stats.packetsReceived - previousPacketsReceived;
   const currentPacketsLost = stats.packetsLost - previousPacketsLost;
@@ -110,6 +112,8 @@ RTCMonitor.createSample = function createSample(stats, previousSample) {
       bytesReceived: stats.bytesReceived,
       bytesSent: stats.bytesSent
     },
+    bytesSent: currentBytesSent,
+    bytesReceived: currentBytesReceived,
     packetsSent: currentPacketsSent,
     packetsReceived: currentPacketsReceived,
     packetsLost: currentPacketsLost,
@@ -185,7 +189,6 @@ RTCMonitor.prototype._fetchSample = function _fetchSample() {
   return this.getSample().then(
     function addSample(sample) {
       self._addSample(sample);
-      self._checkIceConnection();
       self._raiseWarnings();
       self.emit('sample', sample);
       return sample;
@@ -211,32 +214,6 @@ RTCMonitor.prototype._addSample = function _addSample(sample) {
   // available for all {sampleBufferSize} threshold validations.
   if (samples.length > SAMPLE_COUNT_METRICS) {
     samples.splice(0, samples.length - SAMPLE_COUNT_METRICS);
-  }
-};
-
-/**
- * Raise disconnect event base on bytes sent and received
- * @private
- */
-RTCMonitor.prototype._checkIceConnection = function _checkIceConnection() {
-  // How many samples we need to check within the last few seconds (ICE_DISCONNECT_THRESHOLD)
-  const samplesNeeded = Math.floor(ICE_DISCONNECT_THRESHOLD / SAMPLE_INTERVAL);
-
-  // Grab the samples we need starting from most recent.
-  const sampleBytes = this._sampleBuffer.slice(this._sampleBuffer.length - samplesNeeded)
-    .map(sample => ({ sent: sample.totals.bytesSent, received: sample.totals.bytesReceived }));
-
-  // No enough samples
-  if (sampleBytes.length < samplesNeeded && this._sampleBuffer.length < SAMPLE_COUNT_METRICS) {
-    return;
-  }
-
-  const noActivity = sampleBytes.every(bytes => sampleBytes[0].sent === bytes.sent) ||
-    sampleBytes.every(bytes => sampleBytes[0].received === bytes.received);
-
-  if (noActivity && Date.now() - this._lastDisconnect >= ICE_DISCONNECT_THRESHOLD) {
-    this._lastDisconnect = Date.now();
-    this.emit('disconnect', this._peerConnection);
   }
 };
 

--- a/lib/twilio/rtc/monitor.js
+++ b/lib/twilio/rtc/monitor.js
@@ -3,6 +3,9 @@ const getStatistics = require('./stats');
 const inherits = require('util').inherits;
 const Mos = require('./mos');
 
+// Inactivity wait duration before we raise ice 'disconnect'
+const ICE_DISCONNECT_THRESHOLD = 3000;
+
 // How many samples we use when testing metric thresholds
 const SAMPLE_COUNT_METRICS = 5;
 
@@ -55,6 +58,7 @@ function RTCMonitor(options) {
   Object.defineProperties(this, {
     _activeWarnings: { value: new Map() },
     _currentStreaks: { value: new Map() },
+    _lastDisconnect: { value: 0, writable: true },
     _peerConnection: { value: options.peerConnection, writable: true },
     _sampleBuffer: { value: [] },
     _sampleInterval: { value: null, writable: true },
@@ -181,6 +185,7 @@ RTCMonitor.prototype._fetchSample = function _fetchSample() {
   return this.getSample().then(
     function addSample(sample) {
       self._addSample(sample);
+      self._checkIceConnection();
       self._raiseWarnings();
       self.emit('sample', sample);
       return sample;
@@ -206,6 +211,32 @@ RTCMonitor.prototype._addSample = function _addSample(sample) {
   // available for all {sampleBufferSize} threshold validations.
   if (samples.length > SAMPLE_COUNT_METRICS) {
     samples.splice(0, samples.length - SAMPLE_COUNT_METRICS);
+  }
+};
+
+/**
+ * Raise disconnect event base on bytes sent and received
+ * @private
+ */
+RTCMonitor.prototype._checkIceConnection = function _checkIceConnection() {
+  // How many samples we need to check within the last few seconds (ICE_DISCONNECT_THRESHOLD)
+  const samplesNeeded = Math.floor(ICE_DISCONNECT_THRESHOLD / SAMPLE_INTERVAL);
+
+  // Grab the samples we need starting from most recent.
+  const sampleBytes = this._sampleBuffer.slice(this._sampleBuffer.length - samplesNeeded)
+    .map(sample => ({ sent: sample.totals.bytesSent, received: sample.totals.bytesReceived }));
+
+  // No enough samples
+  if (sampleBytes.length < samplesNeeded && this._sampleBuffer.length < SAMPLE_COUNT_METRICS) {
+    return;
+  }
+
+  const noActivity = sampleBytes.every(bytes => sampleBytes[0].sent === bytes.sent) ||
+    sampleBytes.every(bytes => sampleBytes[0].received === bytes.received);
+
+  if (noActivity && Date.now() - this._lastDisconnect >= ICE_DISCONNECT_THRESHOLD) {
+    this._lastDisconnect = Date.now();
+    this.emit('disconnect', this._peerConnection);
   }
 };
 

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -575,42 +575,41 @@ PeerConnection.prototype._setupPeerConnection = function(rtcConstraints, rtcConf
   return version;
 };
 PeerConnection.prototype._setupChannel = function() {
-  const self = this;
   const pc = this.version.pc;
 
   // Chrome 25 supports onopen
-  self.version.pc.onopen = () => {
-    self.status = 'open';
-    self.onopen();
+  this.version.pc.onopen = () => {
+    this.status = 'open';
+    this.onopen();
   };
 
   // Chrome 26 doesn't support onopen so must detect state change
-  self.version.pc.onstatechange = () => {
-    if (self.version.pc && self.version.pc.readyState === 'stable') {
-      self.status = 'open';
-      self.onopen();
+  this.version.pc.onstatechange = () => {
+    if (this.version.pc && this.version.pc.readyState === 'stable') {
+      this.status = 'open';
+      this.onopen();
     }
   };
 
   // Chrome 27 changed onstatechange to onsignalingstatechange
-  self.version.pc.onsignalingstatechange = () => {
+  this.version.pc.onsignalingstatechange = () => {
     const state = pc.signalingState;
-    self.log(`signalingState is "${state}"`);
+    this.log(`signalingState is "${state}"`);
 
-    if (self.version.pc && self.version.pc.signalingState === 'stable') {
-      self.status = 'open';
-      self.onopen();
+    if (this.version.pc && this.version.pc.signalingState === 'stable') {
+      this.status = 'open';
+      this.onopen();
     }
 
-    self.onsignalingstatechange(pc.signalingState);
+    this.onsignalingstatechange(pc.signalingState);
   };
 
-  pc.onicecandidate = function onicecandidate(event) {
-    self.onicecandidate(event.candidate);
+  pc.onicecandidate =  event => {
+    this.onicecandidate(event.candidate);
   };
 
   pc.onicegatheringstatechange = () => {
-    self.onicegatheringstatechange(pc.iceGatheringState);
+    this.onicegatheringstatechange(pc.iceGatheringState);
   };
 
   pc.oniceconnectionstatechange = () => {
@@ -624,35 +623,34 @@ PeerConnection.prototype._setupChannel = function() {
       case 'connected':
         if (previousState === 'disconnected') {
           message = 'ICE liveliness check succeeded. Connection with Twilio restored';
-          self.log(message);
-          self.onreconnect(message);
+          this.log(message);
+          this.onreconnect(message);
         }
         break;
       case 'disconnected':
         message = 'ICE liveliness check failed. May be having trouble connecting to Twilio';
-        self.log(message);
-        self.ondisconnect(message);
+        this.log(message);
+        this.ondisconnect(message);
         break;
       case 'failed':
         // Takes care of checking->failed and disconnected->failed
-        message = `${previousState === 'checking'
+        message = previousState === 'checking'
           ? 'ICE negotiation with Twilio failed.'
-          : 'Connection with Twilio was interrupted.'} Call will terminate.`;
+          : 'Connection with Twilio was interrupted.';
 
-        self.log(message);
-        self.onerror({
+        this.log(message);
+        this.onerror({
           info: {
             code: 31003,
             message
-          },
-          disconnect: true
+          }
         });
         break;
       default:
-        self.log(`iceConnectionState is "${state}"`);
+        this.log(`iceConnectionState is "${state}"`);
     }
 
-    self.oniceconnectionstatechange(state);
+    this.oniceconnectionstatechange(state);
   };
 };
 PeerConnection.prototype._initializeMediaStream = function(rtcConstraints, rtcConfiguration) {
@@ -672,6 +670,39 @@ PeerConnection.prototype._initializeMediaStream = function(rtcConstraints, rtcCo
   this._setupChannel();
   return true;
 };
+
+/**
+ * Restarts ICE for the current connection
+ * @private
+ */
+PeerConnection.prototype.iceRestart = function() {
+  return new Promise((resolve, reject) => {
+    this.log('Attempting to restart ICE...');
+    this.version.createOffer(this.codecPreferences, { iceRestart: true }).then(() => {
+      this._onAnswerOrRinging = payload => {
+        if (!payload.sdp) { return reject(); }
+
+        this._answerSdp = payload.sdp;
+        this.pstream.removeListener('answer', this._onAnswerOrRinging);
+
+        if (this.status !== 'closed') {
+          return this.version.processAnswer(this.codecPreferences, payload.sdp, resolve, err => {
+            const errMsg = err.message || err;
+            this.onerror({ info: { code: 31000, message: `Error processing answer to re-invite: ${errMsg}` } });
+            reject(err);
+          });
+        }
+        return reject();
+      };
+      this.pstream.addListener('answer', this._onAnswerOrRinging);
+      this.pstream.publish('reinvite', {
+        sdp: this.version.getSDP(),
+        callsid: this.callSid
+      });
+    }, reject);
+  });
+};
+
 PeerConnection.prototype.makeOutgoingCall = function(token, params, callsid, rtcConstraints, rtcConfiguration, onMediaStarted) {
   if (!this._initializeMediaStream(rtcConstraints, rtcConfiguration)) {
     return;

--- a/lib/twilio/rtc/rtcpc.js
+++ b/lib/twilio/rtc/rtcpc.js
@@ -42,7 +42,7 @@ RTCPC.prototype.createModernConstraints = c => {
   // constraint capitalized. Firefox, on the other hand, has deprecated the
   // 'mandatory' key and does not expect the first letter of each constraint
   // capitalized.
-  const nc = {};
+  const nc = Object.assign({}, c);
   if (typeof webkitRTCPeerConnection !== 'undefined' && !util.isEdge()) {
     nc.mandatory = {};
     if (typeof c.audio !== 'undefined') {
@@ -59,6 +59,10 @@ RTCPC.prototype.createModernConstraints = c => {
       nc.offerToReceiveVideo = c.video;
     }
   }
+
+  delete nc.audio;
+  delete nc.video;
+
   return nc;
 };
 RTCPC.prototype.createOffer = function(codecPreferences, constraints, onSuccess, onError) {

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -589,6 +589,80 @@ describe('PeerConnection', () => {
 
   });
 
+  context('PeerConnection.prototype.iceRestart', () => {
+    const METHOD = PeerConnection.prototype.iceRestart;
+    const SDP = 'sdp';
+    const CALLSID = 'callsid';
+
+    let context;
+    let onAnswerOrRinging;
+    let pstream;
+    let toTest;
+    let version;
+
+    beforeEach(() => {
+      onAnswerOrRinging = () => {};
+      version = {
+        createOffer: sinon.stub().returns({ then: (cb) => cb()}),
+        getSDP: () => SDP,
+        processAnswer: (codecPreferences, sdp, onSuccess, onError) => onSuccess(),
+      };
+      pstream = {
+        addListener: (type, callback) => {
+          if (type === 'answer') {
+            onAnswerOrRinging = callback;
+          }
+        },
+        removeListener: sinon.stub(),
+        publish: sinon.stub(),
+      };
+      context = {
+        callSid: CALLSID,
+        codecPreferences: ['opus'],
+        log: sinon.stub(),
+        onerror: sinon.stub(),
+        pstream,
+        version
+      };
+      toTest = METHOD.bind(context);
+    });
+
+    it('Should call createOffer with iceRestart flag', (done) => {
+      toTest().then(() => {
+        assert(version.createOffer.calledWithExactly(context.codecPreferences, {iceRestart: true}));
+        done();
+      });
+      onAnswerOrRinging({sdp: SDP});
+    });
+
+    it('Should publish reinvite', (done) => {
+      toTest().then(() => {
+        assert(pstream.publish.calledWithExactly('reinvite', {
+          sdp: SDP,
+          callsid: CALLSID
+        }));
+        done();
+      });
+      onAnswerOrRinging({sdp: SDP});
+    });
+
+    it('Should remove answer callback', (done) => {
+      toTest().then(() => {
+        assert(pstream.removeListener.calledWithExactly('answer', onAnswerOrRinging));
+        done();
+      });
+      onAnswerOrRinging({sdp: SDP});
+    });
+
+    it('Should update _answerSdp', (done) => {
+      toTest().then(() => {
+        assert.equal(context._answerSdp, SDP);
+        done();
+      });
+      onAnswerOrRinging({sdp: SDP});
+    });
+  });
+
   context('PeerConnection.prototype.makeOutgoingCall', () => {
     const METHOD = PeerConnection.prototype.makeOutgoingCall;
     const EXPECTED_OFFER_ERROR = {info: {code: 31000, message: 'Error creating the offer: error message'}};
@@ -829,7 +903,7 @@ describe('PeerConnection', () => {
       assert.equal(context._setupChannel.called, false);
     });
 
-    it('Should call setup peer connection and return true when status is not open and pstreaem status is not disconnected', () => {
+    it('Should call setup peer connection and return true when status is not open and pstream status is not disconnected', () => {
       assert.strictEqual(toTest(), true);
       assert(context._setupPeerConnection.calledWithExactly(CONSTRAINTS, ICE_SERVERS));
       assert(context._setupChannel.calledWithExactly());

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -1280,6 +1280,36 @@ describe('Connection', function() {
     });
   });
 
+  describe('on monitor.disconnect', () => {
+    afterEach(() => {
+      mediaStream.iceRestart.reset();
+    });
+
+    it('should call mediaStream.iceRestart', () => {
+      mediaStream.iceRestart = sinon.stub().returns({ then: (cb: any) => cb() });
+      monitor.emit('disconnect');
+      sinon.assert.callCount(mediaStream.iceRestart, 1);
+    });
+
+    it('should listen to monitor.disconnect again after each previous ice restarts', () => {
+      mediaStream.iceRestart = sinon.stub().returns({ then: (cb: any) => cb() });
+      monitor.emit('disconnect');
+      monitor.emit('disconnect');
+      monitor.emit('disconnect');
+      monitor.emit('disconnect');
+      monitor.emit('disconnect');
+      sinon.assert.callCount(mediaStream.iceRestart, 5);
+    });
+
+    it('should not call mediaStream.iceRestart if a previous restart is pending', () => {
+      mediaStream.iceRestart = sinon.stub().returns({ then: () => {} });
+      monitor.emit('disconnect');
+      monitor.emit('disconnect');
+      monitor.emit('disconnect');
+      sinon.assert.callCount(mediaStream.iceRestart, 1);
+    });
+  });
+
   describe('on monitor.sample', () => {
     const sampleData = {
       timestamp: 0,

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -1280,36 +1280,6 @@ describe('Connection', function() {
     });
   });
 
-  describe('on monitor.disconnect', () => {
-    afterEach(() => {
-      mediaStream.iceRestart.reset();
-    });
-
-    it('should call mediaStream.iceRestart', () => {
-      mediaStream.iceRestart = sinon.stub().returns({ then: (cb: any) => cb() });
-      monitor.emit('disconnect');
-      sinon.assert.callCount(mediaStream.iceRestart, 1);
-    });
-
-    it('should listen to monitor.disconnect again after each previous ice restarts', () => {
-      mediaStream.iceRestart = sinon.stub().returns({ then: (cb: any) => cb() });
-      monitor.emit('disconnect');
-      monitor.emit('disconnect');
-      monitor.emit('disconnect');
-      monitor.emit('disconnect');
-      monitor.emit('disconnect');
-      sinon.assert.callCount(mediaStream.iceRestart, 5);
-    });
-
-    it('should not call mediaStream.iceRestart if a previous restart is pending', () => {
-      mediaStream.iceRestart = sinon.stub().returns({ then: () => {} });
-      monitor.emit('disconnect');
-      monitor.emit('disconnect');
-      monitor.emit('disconnect');
-      sinon.assert.callCount(mediaStream.iceRestart, 1);
-    });
-  });
-
   describe('on monitor.sample', () => {
     const sampleData = {
       timestamp: 0,

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -1335,6 +1335,30 @@ describe('Connection', function() {
   });
 
   describe('on monitor.warning', () => {
+    context('if warningData.name contains bytes', () => {
+      it('should start iceRestart loop for bytesReceived', () => {
+        mediaStream.iceRestart = sinon.stub();
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'maxDuration' } });
+        clock.tick(4000);
+        assert(mediaStream.iceRestart.calledOnce);
+      });
+      it('should start iceRestart loop for bytesSent', () => {
+        mediaStream.iceRestart = sinon.stub();
+        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'maxDuration' } });
+        clock.tick(4000);
+        assert(mediaStream.iceRestart.calledOnce);
+      });
+      it('should start iceRestart loop once', () => {
+        mediaStream.iceRestart = sinon.stub();
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'maxDuration' } });
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'maxDuration' } });
+        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'maxDuration' } });
+        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'maxDuration' } });
+        clock.tick(4000);
+        assert(mediaStream.iceRestart.calledOnce);
+      });
+    });
+
     context('if warningData.name contains audio', () => {
       it('should publish an audio-level-warning-raised warning event', () => {
         monitor.emit('warning', { name: 'audio', threshold: { name: 'max' }, values: [1, 2, 3] });
@@ -1361,6 +1385,24 @@ describe('Connection', function() {
   });
 
   describe('on monitor.warning-cleared', () => {
+    context('if warningData.name contains bytes', () => {
+      it('should stop iceRestart loop for bytesReceived', () => {
+        mediaStream.iceRestart = sinon.stub();
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'maxDuration' } });
+        clock.tick(4000);
+        monitor.emit('warning-cleared', { name: 'bytesReceived', threshold: { name: 'maxDuration' } });
+        clock.tick(4000);
+        assert(mediaStream.iceRestart.calledOnce);
+      });
+      it('should stop iceRestart loop for bytesSent', () => {
+        mediaStream.iceRestart = sinon.stub();
+        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'maxDuration' } });
+        clock.tick(4000);
+        monitor.emit('warning-cleared', { name: 'bytesSent', threshold: { name: 'maxDuration' } });
+        clock.tick(4000);
+        assert(mediaStream.iceRestart.calledOnce);
+      });
+    });
     context('if warningData.name contains audio', () => {
       it('should publish an audio-level-warning-cleared info event', () => {
         monitor.emit('warning-cleared', { name: 'audio', threshold: { name: 'max' } });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6145](https://issues.corp.twilio.com/browse/CLIENT-6145)
- [CLIENT-5873](https://issues.corp.twilio.com/browse/CLIENT-5873)

### Description

ICE Connections will now attempt to reconnect when they transition to the `failed` state, rather than immediately disconnecting. See [Jira CLIENT-6145](https://issues.corp.twilio.com/browse/CLIENT-6145) for more details.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
