### PR TITLE
Adjust warning delay from 20 secs to 5 secs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements
 * ICE Connections will now attempt to reconnect when they transition to the `failed` state, rather
   than immediately disconnecting.
 * We now report bytesSent and bytesReceived within the last second in the webrtc sample object (`RTCSample`).
+* We now emit warnings 5 seconds after the start of a call (originally at 20 seconds).
 
 Bug Fixes
 ---------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Improvements
 * ICE Connections will now attempt to reconnect when they transition to the `failed` state, rather
   than immediately disconnecting.
 * We now report bytesSent and bytesReceived within the last second in the webrtc sample object (`RTCSample`).
-* We now emit warnings 5 seconds after the start of a call (originally at 20 seconds).
+* We now begin monitoring for warnings 5 seconds after the start of a call (originally at 20 seconds).
 
 Bug Fixes
 ---------

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -45,7 +45,7 @@ const DTMF_TONE_DURATION: number = 160;
 
 const ICE_RESTART_INTERVAL = 3000;
 const METRICS_BATCH_SIZE: number = 10;
-const METRICS_DELAY: number = 20000;
+const METRICS_DELAY: number = 5000;
 
 const WARNING_NAMES: Record<string, string> = {
   audioInputLevel: 'audio-input-level',

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -108,8 +108,8 @@ describe('Connection', function() {
       sinon.assert.calledOnce(monitor.disableWarnings);
     });
 
-    it('should enable monitor warnings after 20000 ms', () => {
-      clock.tick(20000 - 10);
+    it('should enable monitor warnings after 5000 ms', () => {
+      clock.tick(5000 - 10);
       sinon.assert.notCalled(monitor.enableWarnings);
       clock.tick(20);
       sinon.assert.calledOnce(monitor.enableWarnings);


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

Changing warning delay from 20 seconds to 5 seconds

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
