### PR TITLE
CLIENT-6229 | Fix bug causing some websocket errors to not surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Bug Fixes
 ---------
 
 * Fixed a bug where changing the input device then later calling `Connection.mute()` will not work.
+* Fixed a bug causing some signaling errors to not trigger an error event from Connection.
 
 
 1.7.3 (May 16, 2019)

--- a/lib/twilio/pstream.js
+++ b/lib/twilio/pstream.js
@@ -111,8 +111,14 @@ PStream.prototype._handleTransportClose = function() {
   }
 };
 
-PStream.prototype._handleTransportError = function(err) {
-  this.emit('error', err);
+PStream.prototype._handleTransportError = function(error) {
+  if (!error) {
+    this.emit('error', { error: { code: 31000, message: 'Websocket closed without a provided reason' } });
+    return;
+  }
+  // We receive some errors without call metadata (just the error). We need to convert these
+  // to be contained within the 'error' field so that these errors match the expected format.
+  this.emit('error', typeof error.code !== 'undefined' ?  { error } : error);
 };
 
 PStream.prototype._handleTransportMessage = function(msg) {

--- a/tests/pstream.js
+++ b/tests/pstream.js
@@ -80,9 +80,30 @@ describe('PStream', () => {
   });
 
   describe('when transport fires onerror', () => {
-    it('should fire error', (done) => {
-      pstream.on('error', () => done());
-      pstream.transport.emit('error');
+    it('should fire error with the right format when only error is sent', (done) => {
+      const err = { code: 1234, message: 'foo' };
+
+      pstream.on('error', ({ error }) => {
+        if (error === err) {
+          done();
+        } else {
+          done(new Error('Error payload not correct format'));
+        }
+      });
+      pstream.transport.emit('error', err);
+    });
+
+    it('should fire error with the right format when only error is sent', (done) => {
+      const err = { code: 1234, message: 'foo' };
+
+      pstream.on('error', ({ error }) => {
+        if (error === err) {
+          done();
+        } else {
+          done(new Error('Error payload not correct format'));
+        }
+      });
+      pstream.transport.emit('error', { error: err, callSid: 'CA000' });
     });
 
     it('should not affect status', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6229](https://issues.corp.twilio.com/browse/CLIENT-6229)

### Description

Fixes a bug causing some signaling errors to not trigger an error event from Connection.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
