### PR TITLE
CLIENT-6252 | Stop iceRestart on disconnect

### DIFF
--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -958,6 +958,7 @@ class Connection extends EventEmitter {
     }
 
     this._log.info('Disconnecting...');
+    clearInterval(this._iceRestartIntervalId);
 
     // send pstream hangup message
     if (this.pstream !== null && this.pstream.status !== 'disconnected' && this.sendHangup) {

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -1372,23 +1372,32 @@ describe('Connection', function() {
     context('if warningData.name contains bytes', () => {
       it('should start iceRestart loop for bytesReceived', () => {
         mediaStream.iceRestart = sinon.stub();
-        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'maxDuration' } });
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'min' } });
         clock.tick(4000);
         assert(mediaStream.iceRestart.calledOnce);
       });
       it('should start iceRestart loop for bytesSent', () => {
         mediaStream.iceRestart = sinon.stub();
-        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'maxDuration' } });
+        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'min' } });
         clock.tick(4000);
         assert(mediaStream.iceRestart.calledOnce);
       });
       it('should start iceRestart loop once', () => {
         mediaStream.iceRestart = sinon.stub();
-        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'maxDuration' } });
-        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'maxDuration' } });
-        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'maxDuration' } });
-        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'maxDuration' } });
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'min' } });
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'min' } });
+        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'min' } });
+        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'min' } });
         clock.tick(4000);
+        assert(mediaStream.iceRestart.calledOnce);
+      });
+      it('should stop iceRestart loop on disconnect', () => {
+        mediaStream.iceRestart = sinon.stub();
+        (conn as any)['_status'] = Connection.State.Open;
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'min' } });
+        clock.tick(3000);
+        conn.disconnect();
+        clock.tick(3000);
         assert(mediaStream.iceRestart.calledOnce);
       });
     });
@@ -1422,17 +1431,17 @@ describe('Connection', function() {
     context('if warningData.name contains bytes', () => {
       it('should stop iceRestart loop for bytesReceived', () => {
         mediaStream.iceRestart = sinon.stub();
-        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'maxDuration' } });
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'min' } });
         clock.tick(4000);
-        monitor.emit('warning-cleared', { name: 'bytesReceived', threshold: { name: 'maxDuration' } });
+        monitor.emit('warning-cleared', { name: 'bytesReceived', threshold: { name: 'min' } });
         clock.tick(4000);
         assert(mediaStream.iceRestart.calledOnce);
       });
       it('should stop iceRestart loop for bytesSent', () => {
         mediaStream.iceRestart = sinon.stub();
-        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'maxDuration' } });
+        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'min' } });
         clock.tick(4000);
-        monitor.emit('warning-cleared', { name: 'bytesSent', threshold: { name: 'maxDuration' } });
+        monitor.emit('warning-cleared', { name: 'bytesSent', threshold: { name: 'min' } });
         clock.tick(4000);
         assert(mediaStream.iceRestart.calledOnce);
       });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6252](https://issues.corp.twilio.com/browse/CLIENT-6252)

### Description

Stop iceRestart loop on disconnect to prevent infinite restart on hangup if the warning is not cleared.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
