### PR TITLE
Client 6319 | Stop sending reinvites on server hangup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@
 Improvements
 ------------
 
-* Checking whether plan-b or unified-plan is default on the browser now happens on `Device.setup()` or on device initialization with a token, instead of on page load.
+* Checking whether plan-b or unified-plan is default on the browser now happens on `Device.setup()` or on device initialization with a token, instead of on page load. (CLIENT-6279)
+
+Bug Fixes
+---------
+
+* Fixed a bug where ICE restarts will continue to retry when a call gets disconnected while ringing. (CLIENT-6319)
+* `Device.destroy` now disconnects all connections. (CLIENT-6319)
+
 
 1.7.4 (June 21, 2019)
 ====================

--- a/lib/twilio/deferred.ts
+++ b/lib/twilio/deferred.ts
@@ -1,0 +1,55 @@
+/**
+ * @module Voice
+ * @internalapi
+ */
+
+/**
+ * Deferred Promise
+ */
+export default class Deferred {
+  /**
+   * This {@link Deferred} promise
+   */
+  private readonly _promise: Promise<any>;
+
+  /**
+   * Rejects this promise
+   */
+  private _reject: (reason?: any) => void;
+
+  /**
+   * Resolves this promise
+   */
+  private _resolve: (value?: any) => void;
+
+  /**
+   * @constructor
+   */
+  constructor() {
+    this._promise = new Promise<any>((resolve, reject) => {
+      this._resolve = resolve;
+      this._reject = reject;
+    });
+  }
+
+  /**
+   * @returns The {@link Deferred} promise
+   */
+  get promise(): Promise<any> {
+    return this._promise;
+  }
+
+  /**
+   * Rejects this promise
+   */
+  reject(reason?: any): void {
+    this._reject(reason);
+  }
+
+  /**
+   * Resolves this promise
+   */
+  resolve(value?: any): void {
+    this._resolve(value);
+  }
+}

--- a/lib/twilio/deferred.ts
+++ b/lib/twilio/deferred.ts
@@ -8,17 +8,17 @@
  */
 export default class Deferred {
   /**
-   * This {@link Deferred} promise
+   * This {@link Deferred} Promise
    */
   private readonly _promise: Promise<any>;
 
   /**
-   * Rejects this promise
+   * The Promise's reject method.
    */
   private _reject: (reason?: any) => void;
 
   /**
-   * Resolves this promise
+   * The Promise's resolve method.
    */
   private _resolve: (value?: any) => void;
 
@@ -33,7 +33,7 @@ export default class Deferred {
   }
 
   /**
-   * @returns The {@link Deferred} promise
+   * @returns The {@link Deferred} Promise
    */
   get promise(): Promise<any> {
     return this._promise;

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -420,6 +420,7 @@ class Device extends EventEmitter {
    * Destroy the {@link Device}, freeing references to be garbage collected.
    */
   destroy(): void {
+    this._disconnectAll();
     this._stopRegistrationTimer();
 
     if (this.audio) {

--- a/lib/twilio/pstream.js
+++ b/lib/twilio/pstream.js
@@ -44,6 +44,7 @@ function PStream(token, uri, options) {
   this.gateway = null;
   this.region = null;
   this._messageQueue = [];
+  this._reinviteDeferreds = new Map();
 
   this._handleTransportClose = this._handleTransportClose.bind(this);
   this._handleTransportError = this._handleTransportError.bind(this);
@@ -129,6 +130,19 @@ PStream.prototype._handleTransportMessage = function(msg) {
   const { type, payload = {} } = JSON.parse(msg.data);
   this.gateway = payload.gateway || this.gateway;
   this.region = payload.region || this.region;
+
+  // Resolve our deferred reinvite if there's any
+  const deferred = this._reinviteDeferreds.get(payload.callsid);
+  if (deferred) {
+    if (type === 'answer') {
+      deferred.resolve(payload);
+      this._reinviteDeferreds.delete(payload.callsid);
+    } else if (type === 'hangup') {
+      deferred.reject();
+      this._reinviteDeferreds.delete(payload.callsid);
+    }
+  }
+
   this.emit(type, payload);
 };
 
@@ -161,6 +175,21 @@ PStream.prototype.register = function(mediaCapabilities) {
     media: mediaCapabilities
   };
   this._publish('register', regPayload, true);
+};
+
+PStream.prototype.reinvite = function(sdp, callsid) {
+  let handlers;
+  const deferred = this._reinviteDeferreds.get(callsid);
+  const promise = deferred ? deferred.promise : new Promise((resolve, reject) => {
+    handlers = { resolve, reject };
+  });
+
+  if (handlers) {
+    this._reinviteDeferreds.set(callsid, Object.assign({ promise }, handlers));
+  }
+
+  this._publish('reinvite', { sdp, callsid }, false);
+  return promise;
 };
 
 PStream.prototype._destroy = function() {

--- a/lib/twilio/pstream.js
+++ b/lib/twilio/pstream.js
@@ -3,6 +3,7 @@ const EventEmitter = require('events').EventEmitter;
 const util = require('util');
 const log = require('./log');
 
+const Deferred = require('./deferred').default;
 const WSTransport = require('./wstransport').default;
 
 const PSTREAM_VERSION = '1.5';
@@ -178,18 +179,11 @@ PStream.prototype.register = function(mediaCapabilities) {
 };
 
 PStream.prototype.reinvite = function(sdp, callsid) {
-  let handlers;
-  const deferred = this._reinviteDeferreds.get(callsid);
-  const promise = deferred ? deferred.promise : new Promise((resolve, reject) => {
-    handlers = { resolve, reject };
-  });
-
-  if (handlers) {
-    this._reinviteDeferreds.set(callsid, Object.assign({ promise }, handlers));
-  }
+  const deferred = this._reinviteDeferreds.get(callsid) || new Deferred();
+  this._reinviteDeferreds.set(callsid, deferred);
 
   this._publish('reinvite', { sdp, callsid }, false);
-  return promise;
+  return deferred.promise;
 };
 
 PStream.prototype._destroy = function() {

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -674,32 +674,26 @@ PeerConnection.prototype._initializeMediaStream = function(rtcConstraints, rtcCo
 /**
  * Restarts ICE for the current connection
  * @private
+ * @returns A promise that rejects with a boolean representing whether or not ICE restart should still be attempted.
  */
 PeerConnection.prototype.iceRestart = function() {
   return new Promise((resolve, reject) => {
     this.log('Attempting to restart ICE...');
     this.version.createOffer(this.codecPreferences, { iceRestart: true }).then(() => {
-      this._onAnswerOrRinging = payload => {
-        if (!payload.sdp) { return reject(); }
+      this.pstream.reinvite(this.version.getSDP(), this.callSid).then(payload => {
+        if (!payload.sdp) { return reject(true); }
 
         this._answerSdp = payload.sdp;
-        this.pstream.removeListener('answer', this._onAnswerOrRinging);
-
         if (this.status !== 'closed') {
           return this.version.processAnswer(this.codecPreferences, payload.sdp, resolve, err => {
             const errMsg = err.message || err;
             this.onerror({ info: { code: 31000, message: `Error processing answer to re-invite: ${errMsg}` } });
-            reject(err);
+            reject(true);
           });
         }
-        return reject();
-      };
-      this.pstream.addListener('answer', this._onAnswerOrRinging);
-      this.pstream.publish('reinvite', {
-        sdp: this.version.getSDP(),
-        callsid: this.callSid
-      });
-    }, reject);
+        return reject(true);
+      }, () => reject(false));
+    }, () => reject(true));
   });
 };
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -76,6 +76,7 @@ require('./sdp');
 
 require('./unit/connection');
 require('./unit/device');
+require('./unit/deferred');
 require('./unit/tslog');
 require('./unit/wstransport');
 require('./unit/rtc/monitor');

--- a/tests/pstream.js
+++ b/tests/pstream.js
@@ -230,6 +230,121 @@ describe('PStream', () => {
       });
     });
   });
+
+  describe('reinvite', () => {
+    const callsid = 'foo';
+    const sdp = 'bar';
+
+    const getMessage = (type) => ({
+      data: JSON.stringify({
+        type, payload: { sdp, callsid }
+      })
+    });
+
+    let wait;
+
+    beforeEach(() => {
+      wait = (timer) => new Promise(r => setTimeout(r, timer || 0));
+    });
+
+    it('should resolve once', () => {
+      const callback = sinon.stub();
+      const error = sinon.stub();
+      pstream.reinvite(sdp, callsid).then(callback).catch(error);
+      pstream._handleTransportMessage(getMessage('answer'));
+      pstream._handleTransportMessage(getMessage('answer'));
+
+      return wait().then(() => {
+        assert(error.notCalled);
+        sinon.assert.callCount(callback, 1);
+        assert.equal(pstream._reinviteDeferreds.get(callsid), undefined);
+      });
+    });
+
+    it('should reject once', () => {
+      const callback = sinon.stub();
+      const error = sinon.stub();
+      pstream.reinvite(sdp, callsid).then(callback).catch(error);
+      pstream._handleTransportMessage(getMessage('hangup'));
+      pstream._handleTransportMessage(getMessage('hangup'));
+
+      return wait().then(() => {
+        assert(callback.notCalled);
+        sinon.assert.callCount(error, 1);
+        assert.equal(pstream._reinviteDeferreds.get(callsid), undefined);
+      });
+    });
+
+    it('should return payload information', (done) => {
+      pstream.reinvite(sdp, callsid).then((payload) => {
+        assert.equal(payload.callsid, callsid);
+        assert.equal(payload.sdp, sdp);
+        done();
+      });
+      pstream._handleTransportMessage(getMessage('answer'));
+    });
+
+    it('should return previous promise if reinvite is called multiple times using the same callsid', () => {
+      const promise1 = pstream.reinvite(sdp, callsid);
+      const promise2 = pstream.reinvite(sdp, callsid);
+
+      assert.notEqual(promise1, undefined);
+      assert.notEqual(promise2, undefined);
+      assert.equal(promise1, promise2);
+    });
+
+    it('should return new promise if reinvite is called multiple times with different callsid', () => {
+      const promise1 = pstream.reinvite(sdp, callsid);
+      const promise2 = pstream.reinvite(sdp, callsid + 'foo');
+
+      assert.notEqual(promise1, undefined);
+      assert.notEqual(promise2, undefined);
+      assert.notEqual(promise1, promise2);
+    });
+
+    [{ type: 'answer', fn: 'then' }, { type: 'hangup', fn: 'catch' }].forEach(item => {
+      it(`should ${item.type} latest reinvite`, () => {
+        // Simulate a scenario where we don't receive a response from the server on the first call
+        let reinviteCount = 0;
+        pstream._publish = () => {
+          if (reinviteCount > 0) {
+            wait(10).then(() => pstream._handleTransportMessage(getMessage(item.type)));
+            reinviteCount++;
+          }
+        };
+
+        const callback = sinon.stub();
+
+        pstream.reinvite(sdp, callsid);
+        reinviteCount++;
+
+        wait(20).then(() => {
+          pstream.reinvite(sdp, callsid)[item.fn](callback);
+          reinviteCount++;
+        });
+
+        return wait(50).then(() => sinon.assert.callCount(callback, 1));
+      });
+
+      it(`should always publish reinvite and receive ${item.type}`, () => {
+        const numReinvites = 8;
+        const timerIncrement = 5;
+        const callback = sinon.stub();
+        pstream._publish = sinon.stub().callsFake(() => {
+          wait(timerIncrement).then(() => pstream._handleTransportMessage(getMessage(item.type)));
+        });
+
+        for (let i = 1; i <= numReinvites; i++) {
+          wait((numReinvites * timerIncrement) + timerIncrement).then(() => pstream.reinvite(sdp, callsid)[item.fn](callback));
+        }
+
+        return wait((numReinvites * timerIncrement * 2) + timerIncrement).then(() => {
+          sinon.assert.callCount(callback, numReinvites);
+          sinon.assert.callCount(pstream._publish, numReinvites);
+        });
+      });
+    });
+  });
 });
 
 class TransportFactory extends EventEmitter {

--- a/tests/unit/deferred.ts
+++ b/tests/unit/deferred.ts
@@ -1,0 +1,36 @@
+import Deferred from '../../lib/twilio/deferred';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+describe('Deferred', () => {
+  const RES = 'foo';
+  const ERR = 'bar';
+
+  let deferred: Deferred;
+  let wait: () => Promise<any>;
+
+  beforeEach(() => {
+    deferred = new Deferred();
+    wait = () => new Promise(r => setTimeout(r, 0));
+  });
+
+  it('Should initialize', () => {
+    assert.notEqual(deferred.promise, null);
+    assert.notEqual(deferred.promise, undefined);
+  });
+
+  it('Should resolve', () => {
+    const callback = sinon.stub();
+    deferred.promise.then(callback);
+    deferred.resolve(RES);
+
+    return wait().then(() => assert(callback.calledWithExactly(RES)));
+  });
+
+  it('Should reject', () => {
+    const callback = sinon.stub();
+    deferred.promise.catch(callback);
+    deferred.reject(ERR);
+    return wait().then(() => assert(callback.calledWithExactly(ERR)));
+  });
+});

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -311,6 +311,22 @@ describe('Device', function() {
         clock.tick(30000 + 1);
         sinon.assert.notCalled(pstream.register);
       });
+
+      it('should disconnect all connections', () => {
+        const disconnect = sinon.spy();
+        (device as any)['connections'] = [
+          { disconnect },
+          { disconnect },
+        ];
+        device.destroy();
+        sinon.assert.calledTwice(disconnect);
+      });
+
+      it('should disconnect active connection', () => {
+        const connection = device.connect();
+        device.destroy();
+        sinon.assert.calledOnce((connection as any).disconnect);
+      });
     });
 
     describe('.disconnectAll()', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6319](https://issues.corp.twilio.com/browse/CLIENT-6319)

### Description
@ryan-rowland  I found a 100% repro steps. See jira link above.

Update summary:
- iceRestart now returns a boolean flag `canRetry` so that the calling function can decide whether it should stop retrying. To make this possible, I made reinvite its own function. It wraps the websocket calls and responses into a promise to easily determine whether the reinvite for a callsid succeeded or failed. Success means we received an `answer`, failed means we received a `hangup` from the server. This helps on stopping the iceRestart loop.
- Device.destroy() now calls disconnectAll()

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
