### PR TITLE
CLIENT-6341 CLIENT-6342 | Ignore warnings if total bytes is zero. Disconnect on signaling failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Bug Fixes
 * Fixed a bug where ICE restarts will continue to retry when a call gets disconnected while ringing. (CLIENT-6319)
 * `Device.destroy` now disconnects all connections. (CLIENT-6319)
 * Fixed a bug where answer is applied multiple times after creating an offer. (CLIENT-6335)
+* Fixed a bug where low-bytes warning is raised if total bytes sent and received is zero or not supported. (CLIENT-6341)
+* Fixed a bug where ICE restart will not stop when connection drops on Firefox. (CLIENT-6342)
 
 
 1.7.4 (June 21, 2019)

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -272,7 +272,7 @@ class Connection extends EventEmitter {
 
         if (samples && samples.every(sample => sample.totals[name] === 0)) {
           // We don't have relevant samples yet, usually at the start of a call.
-          // On Edge browser, this is always zero
+          // This also may mean the browser does not support the required fields.
           return;
         }
 
@@ -297,7 +297,7 @@ class Connection extends EventEmitter {
 
         if (samples && samples.every(sample => sample.totals[name] === 0)) {
           // We don't have relevant samples yet, usually at the start of a call.
-          // On Edge browser, this is always zero
+          // This also may mean the browser does not support the required fields.
           return;
         }
 

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -423,6 +423,10 @@ class Connection extends EventEmitter {
     this.pstream.on('cancel', this._onCancel);
     this.pstream.on('ringing', this._onRinging);
 
+    // When websocket gets disconnected
+    // There's no way to retry this session so we disconnect
+    this.pstream.on('offline', this._disconnect.bind(this));
+
     this.on('error', error => {
       this._publisher.error('connection', 'error', {
         code: error.code, message: error.message,

--- a/lib/twilio/rtc/monitor.ts
+++ b/lib/twilio/rtc/monitor.ts
@@ -380,18 +380,18 @@ class RTCMonitor extends EventEmitter {
     if (typeof limits.max === 'number') {
       count = countHigh(limits.max, values);
       if (count >= raiseCount) {
-        this._raiseWarning(statName, 'max', { values });
+        this._raiseWarning(statName, 'max', { values, samples: relevantSamples });
       } else if (count <= clearCount) {
-        this._clearWarning(statName, 'max', { values });
+        this._clearWarning(statName, 'max', { values, samples: relevantSamples });
       }
     }
 
     if (typeof limits.min === 'number') {
       count = countLow(limits.min, values);
       if (count >= raiseCount) {
-        this._raiseWarning(statName, 'min', { values });
+        this._raiseWarning(statName, 'min', { values, samples: relevantSamples });
       } else if (count <= clearCount) {
-        this._clearWarning(statName, 'min', { values });
+        this._clearWarning(statName, 'min', { values, samples: relevantSamples });
       }
     }
 

--- a/lib/twilio/rtc/warning.ts
+++ b/lib/twilio/rtc/warning.ts
@@ -16,6 +16,11 @@ export default interface RTCWarning {
   name?: string;
 
   /**
+   * List of samples for this {@link RTCWarning}.
+   */
+  samples?: RTCSample[];
+
+  /**
    * Threshold data for this {@link RTCWarning}.
    */
   threshold?: ThresholdWarningData;
@@ -26,9 +31,9 @@ export default interface RTCWarning {
   value?: number;
 
   /**
-   * A list of sample data
+   * A list of values for the stat in this {@link RTCWarning}.
    */
-  values?: RTCSample[];
+  values?: number[];
 }
 
 /**


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6341](https://issues.corp.twilio.com/browse/CLIENT-6341)
- [CLIENT-6342](https://issues.corp.twilio.com/browse/CLIENT-6342)

### Description

- do not trigger ice restart if total bytes is zero
- when websocket gets disconnected, we also disconnect the current call since there's no way to resume the call once websocket is disconnected.

**Details why it's happening only on Firefox:**
Firefox throws an error when calling createOffer during iceRestart when you lose internet connection. We rely on the server to return a 'hangup' event to stop retrying. Since firefox won't get passed the createOffer step, we will never get a response back from the server.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
