### PR TITLE
CLIENT-6284 | Reconnection state APIs

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -887,7 +887,7 @@ class Device extends EventEmitter {
     });
 
     connection.addListener('error', (error: Connection.Error) => {
-      if (connection.status() === 'closed') {
+      if (connection.state() === Connection.State.Disconnected) {
         this._removeConnection(connection);
       }
       if (this.audio) {
@@ -907,7 +907,7 @@ class Device extends EventEmitter {
       this.emit('cancel', connection);
     });
 
-    connection.once('disconnect', () => {
+    connection.once('disconnected', () => {
       if (this.audio) {
         this.audio._maybeStopPollingVolume();
       }

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -660,11 +660,12 @@ PeerConnection.prototype._initializeMediaStream = function(rtcConstraints, rtcCo
     return false;
   }
   if (this.pstream.status === 'disconnected') {
-    this.onerror({ info: {
+    const info = {
       code: 31000,
       message: 'Cannot establish connection. Client is disconnected'
-    } });
-    this.close();
+    };
+    this.onerror({ info });
+    this.close(info);
     return false;
   }
   this.version = this._setupPeerConnection(rtcConstraints, rtcConfiguration);
@@ -790,7 +791,7 @@ PeerConnection.prototype.answerIncomingCall = function(callSid, sdp, rtcConstrai
   }
   this.version.processSDP(this.codecPreferences, sdp, { audio: true }, onAnswerSuccess, onAnswerError);
 };
-PeerConnection.prototype.close = function() {
+PeerConnection.prototype.close = function(reason) {
   if (this.version && this.version.pc) {
     if (this.version.pc.signalingState !== 'closed') {
       this.version.pc.close();
@@ -824,7 +825,7 @@ PeerConnection.prototype.close = function() {
     this._outputAnalyser2.disconnect();
   }
   this.status = 'closed';
-  this.onclose();
+  this.onclose(reason);
 };
 PeerConnection.prototype.reject = function(callSid) {
   this.callSid = callSid;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-client",
-  "version": "1.7.6-dev",
+  "version": "2.0.0-dev",
   "description": "Javascript SDK for Twilio Client",
   "main": "./es5/twilio.js",
   "license": "Apache-2.0",

--- a/tests/integration/device.ts
+++ b/tests/integration/device.ts
@@ -143,7 +143,7 @@ describe('Device', function() {
       });
 
       it('should hang up', (done) => {
-        connection1.once('disconnect', () => done());
+        connection1.once('disconnected', () => done());
         connection2.disconnect();
       });
     });

--- a/tests/integration/opus.ts
+++ b/tests/integration/opus.ts
@@ -125,7 +125,7 @@ describe('Opus', function() {
       });
 
       it('should hang up', (done) => {
-        connection1.once('disconnect', () => done());
+        connection1.once('disconnected', () => done());
         connection2.disconnect();
       });
     });

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -248,6 +248,7 @@ describe('PeerConnection', () => {
   context('PeerConnection.prototype.close', () => {
     const METHOD = PeerConnection.prototype.close;
 
+    let message = { message: 'foo' };
     let context = null;
     let toTest = null;
     let stream = null;
@@ -291,7 +292,7 @@ describe('PeerConnection', () => {
     });
 
     it('Should stop everyhting, removeListeners, disconnect analysers, close sockets, etc..', () => {
-      toTest();
+      toTest(message);
       assert(context._outputAnalyser.disconnect.calledOnce);
       assert(context._outputAnalyser.disconnect.calledWithExactly());
       assert(context._inputAnalyser.disconnect.calledOnce);
@@ -305,7 +306,7 @@ describe('PeerConnection', () => {
       assert(pc.close.calledOnce);
       assert(pc.close.calledWithExactly());
       assert(context.onclose.calledOnce);
-      assert(context.onclose.calledWithExactly());
+      assert(context.onclose.calledWithExactly(message));
       assert.strictEqual(context.stream, null);
       assert.strictEqual(context.version.pc, null);
       assert.strictEqual(context.status, 'closed');
@@ -318,9 +319,9 @@ describe('PeerConnection', () => {
       context._mediaStreamSource = false;
       context._inputAnalyser = false;
       context._outputAnalyser = false;
-      toTest();
+      toTest(message);
       assert(context.onclose.calledOnce);
-      assert(context.onclose.calledWithExactly());
+      assert(context.onclose.calledWithExactly(message));
       assert.strictEqual(context.stream, null);
       assert.strictEqual(context.version, false);
       assert.strictEqual(context.status, 'closed');
@@ -332,9 +333,9 @@ describe('PeerConnection', () => {
       context.pstream = false;
       context._mediaStreamSource = false;
       context._inputAnalyser = false;
-      toTest();
+      toTest(message);
       assert(context.onclose.calledOnce);
-      assert(context.onclose.calledWithExactly());
+      assert(context.onclose.calledWithExactly(message));
       assert.strictEqual(context.stream, null);
       assert.strictEqual(context.version, false);
       assert.strictEqual(context.status, 'closed');
@@ -348,9 +349,9 @@ describe('PeerConnection', () => {
       context.pstream = false;
       context._mediaStreamSource = false;
       context._outputAnalyser = false;
-      toTest();
+      toTest(message);
       assert(context.onclose.calledOnce);
-      assert(context.onclose.calledWithExactly());
+      assert(context.onclose.calledWithExactly(message));
       assert.strictEqual(context.stream, null);
       assert.strictEqual(context.version, false);
       assert.strictEqual(context.status, 'closed');
@@ -364,9 +365,9 @@ describe('PeerConnection', () => {
       context.pstream = false;
       context._inputAnalyser = false;
       context._outputAnalyser = false;
-      toTest();
+      toTest(message);
       assert(context.onclose.calledOnce);
-      assert(context.onclose.calledWithExactly());
+      assert(context.onclose.calledWithExactly(message));
       assert.strictEqual(context.stream, null);
       assert.strictEqual(context.version, false);
       assert.strictEqual(context.status, 'closed');
@@ -380,9 +381,9 @@ describe('PeerConnection', () => {
       context._mediaStreamSource = false;
       context._inputAnalyser = false;
       context._outputAnalyser = false;
-      toTest();
+      toTest(message);
       assert(context.onclose.calledOnce);
-      assert(context.onclose.calledWithExactly());
+      assert(context.onclose.calledWithExactly(message));
       assert.strictEqual(context.stream, null);
       assert.strictEqual(context.version, false);
       assert.strictEqual(context.status, 'closed');
@@ -395,10 +396,10 @@ describe('PeerConnection', () => {
       context._mediaStreamSource = false;
       context._inputAnalyser = false;
       context._outputAnalyser = false;
-      toTest();
+      toTest(message);
       assert(context.onclose.calledOnce);
       assert(context.mute.calledWithExactly(false));
-      assert(context.onclose.calledWithExactly());
+      assert(context.onclose.calledWithExactly(message));
       assert.strictEqual(context.stream, null);
       assert.strictEqual(context.version, false);
       assert.strictEqual(context.status, 'closed');
@@ -413,10 +414,10 @@ describe('PeerConnection', () => {
       context._mediaStreamSource = false;
       context._inputAnalyser = false;
       context._outputAnalyser = false;
-      toTest();
+      toTest(message);
       assert(context.onclose.calledOnce);
       assert(context.mute.calledWithExactly(false));
-      assert(context.onclose.calledWithExactly());
+      assert(context.onclose.calledWithExactly(message));
       assert.strictEqual(context.stream, null);
       assert.strictEqual(context.version, false);
       assert.strictEqual(context.status, 'closed');
@@ -429,9 +430,9 @@ describe('PeerConnection', () => {
       context._mediaStreamSource = false;
       context._inputAnalyser = false;
       context._outputAnalyser = false;
-      toTest();
+      toTest(message);
       assert(context.onclose.calledOnce);
-      assert(context.onclose.calledWithExactly());
+      assert(context.onclose.calledWithExactly(message));
       assert.strictEqual(context.stream, null);
       assert.strictEqual(context.status, 'closed');
       assert.strictEqual(context.version.pc, null);
@@ -446,9 +447,9 @@ describe('PeerConnection', () => {
       context._mediaStreamSource = false;
       context._inputAnalyser = false;
       context._outputAnalyser = false;
-      toTest();
+      toTest(message);
       assert(context.onclose.calledOnce);
-      assert(context.onclose.calledWithExactly());
+      assert(context.onclose.calledWithExactly(message));
       assert.strictEqual(context.stream, null);
       assert.strictEqual(context.status, 'closed');
       assert.strictEqual(context.version.pc, null);
@@ -959,7 +960,10 @@ describe('PeerConnection', () => {
       pstream.status = PSTREAM_STATUS_DISCONNECTED;
       assert.strictEqual(toTest(), false);
       assert(context.onerror.calledWithExactly(CONNECTION_ERROR));
-      assert(context.close.calledWithExactly());
+      assert(context.close.calledWithExactly({
+        code: 31000,
+        message: 'Cannot establish connection. Client is disconnected'
+      }));
       assert(context.onerror.calledBefore(context.close));
       assert.equal(context._setupPeerConnection.called, false);
       assert.equal(context._setupChannel.called, false);

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -728,7 +728,7 @@ describe('Device', function() {
 
       describe('on connection.error', () => {
         it('should should remove the connection if closed', () => {
-          device.connections[0].status = () => Connection.State.Closed;
+          device.connections[0].state = () => Connection.State.Disconnected;
           device.connections[0].emit('error');
           assert.equal(device.connections.length, 0);
         });
@@ -753,9 +753,9 @@ describe('Device', function() {
         });
       });
 
-      describe('on connection.disconnect', () => {
+      describe('on connection.disconnected', () => {
         it('should emit Device.disconnect', () => {
-          device.connections[0].emit('disconnect');
+          device.connections[0].emit('disconnected');
           sinon.assert.calledOnce(device.emit as any);
           sinon.assert.calledWith(device.emit as any, 'disconnect');
         });
@@ -766,7 +766,7 @@ describe('Device', function() {
           assert.equal(typeof conn, 'object');
           assert.equal(conn, device.activeConnection());
 
-          device.connections[0].emit('disconnect');
+          device.connections[0].emit('disconnected');
           assert.equal(typeof device.activeConnection(), 'undefined');
         });
       });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6284](https://issues.corp.twilio.com/browse/CLIENT-6284)

### Description
* Implements the following
  * Reconnection FRD: https://code.hq.twilio.com/client/sdk-frd/blob/master/voice/reconnection.md
  * Insight events: https://wiki.hq.twilio.com/pages/viewpage.action?spaceKey=ENDA&title=Programmable+Voice+-+Event+List
* Deprecates the following
  * `Connection.status()` to `Connection.state()`
  * `Connection.on('disconnect')` to `Connection.on('disconnected')`
  * `Connection.Status.Open` to `Connection.Status.Connected`
  * `Connection.Status.Closed` to `Connection.Status.Disconnected`
  * `Connection.on('ringing', handler(hasEarlyMedia))` to `Connection.on('ringing', handler(connection, hasEarlyMedia))`

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
