### PR TITLE
Client 6383 client 6372 | Listening to websocket close and checking for signaling state before applying answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+1.7.6 (In Progress)
+====================
+
+Bug Fixes
+---------
+
+* Fixed a bug where active connection gets disconnected when the token expires. (CLIENT-6383)
+* Fixed a bug where an answer during ICE reconnection is applied without a valid offer, resulting into a console error `Failed to set remote answer sdp: Called in wrong state: kStable`. (CLIENT-6372)
+
+
 1.7.5 (Jul 5, 2019)
 ====================
 

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -425,7 +425,7 @@ class Connection extends EventEmitter {
 
     // When websocket gets disconnected
     // There's no way to retry this session so we disconnect
-    this.pstream.transport.on('close', this._disconnect.bind(this));
+    this.pstream.on('transportClosed', this._disconnect.bind(this));
 
     this.on('error', error => {
       this._publisher.error('connection', 'error', {

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -425,7 +425,7 @@ class Connection extends EventEmitter {
 
     // When websocket gets disconnected
     // There's no way to retry this session so we disconnect
-    this.pstream.on('offline', this._disconnect.bind(this));
+    this.pstream.transport.on('close', this._disconnect.bind(this));
 
     this.on('error', error => {
       this._publisher.error('connection', 'error', {

--- a/lib/twilio/pstream.js
+++ b/lib/twilio/pstream.js
@@ -103,6 +103,8 @@ function PStream(token, uri, options) {
 util.inherits(PStream, EventEmitter);
 
 PStream.prototype._handleTransportClose = function() {
+  this.emit('transportClosed');
+
   if (this.status !== 'disconnected') {
     if (this.status !== 'offline') {
       this.emit('offline', this);

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -699,7 +699,7 @@ PeerConnection.prototype.iceRestart = function() {
         if (!payload.sdp) { return reject(true); }
 
         // Either this did not come from createOffer from iceRestart
-        // or a createOffer came in late and a previous anwer has already been applied
+        // or a createOffer came in late and a previous answer has already been applied
         // so we ignore this
         if (this.version.pc.signalingState !== 'have-local-offer') {
           return reject(false);

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -698,6 +698,13 @@ PeerConnection.prototype.iceRestart = function() {
         this._removeReconnectionListeners();
         if (!payload.sdp) { return reject(true); }
 
+        // Either this did not come from createOffer from iceRestart
+        // or a createOffer came in late and a previous anwer has already been applied
+        // so we ignore this
+        if (this.version.pc.signalingState !== 'have-local-offer') {
+          return reject(false);
+        }
+
         this._answerSdp = payload.sdp;
         if (this.status !== 'closed') {
           return this.version.processAnswer(this.codecPreferences, payload.sdp, resolve, err => {

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -629,6 +629,9 @@ describe('PeerConnection', () => {
       version = {
         createOffer: sinon.stub().returns({ then: (cb) => cb()}),
         getSDP: () => SDP,
+        pc: {
+          signalingState: 'have-local-offer'
+        },
         processAnswer: sinon.stub().callsFake((codecPreferences, sdp, onSuccess, onError) => onSuccess()),
       };
       pstream = {
@@ -692,6 +695,17 @@ describe('PeerConnection', () => {
         done();
       });
       context._onAnswerOrRinging({});
+    });
+
+    it('Should return canRetry=false if there is no local offer', (done) => {
+      version.pc.signalingState = 'stable';
+      toTest().catch((canRetry) => {
+        sinon.assert.notCalled(version.processAnswer);
+        assert(!context._removeReconnectionListeners.notCalled);
+        assert.equal(canRetry, false);
+        done();
+      });
+      context._onAnswerOrRinging({ sdp: SDP });
     });
 
     it('Should return canRetry=true on processAnswer fail', (done) => {

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -54,6 +54,10 @@ describe('Connection', function() {
     publisher = createEmitterStub(require('../../lib/twilio/eventpublisher'));
     publisher.postMetrics = sinon.spy(() => Promise.resolve());
 
+    pstream.transport = {
+      on: sinon.stub()
+    };
+
     soundcache = new Map()
     Object.values(Device.SoundName).forEach((soundName: Device.SoundName) => {
       soundcache.set(soundName, { play: sinon.spy() });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6383](https://issues.corp.twilio.com/browse/CLIENT-6383)
- [CLIENT-6372](https://issues.corp.twilio.com/browse/CLIENT-6372)

### Description

- We were using `pstream.on('offline')` to detect network drops which would disconnect the active connection. But signaling server also emits 'offline' event when the token expires, which causes unwanted disconnection. This PR switches to `transport.on('close')` instead which gets emitted on websocket close.
- We are now ignoring iceRestart if signaling state is not `have-local-offer`, which usually happens when a createOffer came in late and a previous answer has already been applied.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
