### PR TITLE
Ignore transportClosed if iceRestart is disabled

### DIFF
--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -424,9 +424,12 @@ class Connection extends EventEmitter {
     this.pstream.on('cancel', this._onCancel);
     this.pstream.on('ringing', this._onRinging);
 
-    // When websocket gets disconnected
-    // There's no way to retry this session so we disconnect
-    this.pstream.on('transportClosed', this._disconnect.bind(this));
+    if (this.options.enableIceRestart) {
+      // When websocket gets disconnected
+      // There's no way to retry this session so we disconnect
+      // This is not needed if ice restart is disabled, signaling will automatically disconnect the connection
+      this.pstream.on('transportClosed', this._disconnect.bind(this));
+    }
 
     this.on('error', error => {
       this._publisher.error('connection', 'error', {

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -1080,6 +1080,32 @@ describe('Connection', function() {
       });
     });
 
+    describe('pstream.transportClosed event', () => {
+      it('should call disconnect if enableIceRestart is true', () => {
+        conn = new Connection(config, Object.assign({
+          callParameters: { CallSid: 'CA123' }
+        }, options));
+
+        conn['_status'] = Connection.State.Open;
+        mediaStream.close = sinon.stub();
+        pstream.emit('transportClosed');
+
+        assert(mediaStream.close.calledOnce);
+      });
+
+      it('should not call disconnect if enableIceRestart is false', () => {
+        conn = new Connection(config, Object.assign({
+          callParameters: { CallSid: 'CA123' }
+        }, options, { enableIceRestart: false }));
+
+        conn['_status'] = Connection.State.Open;
+        mediaStream.close = sinon.stub();
+        pstream.emit('transportClosed');
+
+        assert(mediaStream.close.notCalled);
+      });
+    });
+
     describe('pstream.cancel event', () => {
       context('when the callsid matches', () => {
         beforeEach(() => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

This PR removes listening for `pstream.transportClosed` from inside connection if ice restart is disabled. Initially, transportClosed was used because firefox doesn't trigger disconnect when websocket is closed. But with iceRestart disabled, we should rely on media signaling to raise the disconnect event so we don't lose 31003 error code.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
