### PR TITLE
CLIENT-6284 | Putting reconnection state apis behind a flag

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -784,6 +784,7 @@ class Device extends EventEmitter {
   private _createDefaultPayload = (connection?: Connection): Record<string, any> => {
     const payload: Record<string, any> = {
       dscp: !!this.options.dscp,
+      ice_restart: this.options.enableIceRestart,
       platform: rtc.getMediaEngine(),
       sdk_version: C.RELEASE_VERSION,
       selected_region: this.options.region,
@@ -915,7 +916,7 @@ class Device extends EventEmitter {
       this.emit('cancel', connection);
     });
 
-    connection.once('disconnected', () => {
+    connection.once(this.options.enableIceRestart ? Connection.State.Disconnected : 'disconnect', () => {
       if (this.audio) {
         this.audio._maybeStopPollingVolume();
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-client",
-  "version": "2.0.0-dev",
+  "version": "1.8.0-dev",
   "description": "Javascript SDK for Twilio Client",
   "main": "./es5/twilio.js",
   "license": "Apache-2.0",

--- a/tests/integration/device.ts
+++ b/tests/integration/device.ts
@@ -143,7 +143,7 @@ describe('Device', function() {
       });
 
       it('should hang up', (done) => {
-        connection1.once('disconnected', () => done());
+        connection1.once('disconnect', () => done());
         connection2.disconnect();
       });
     });

--- a/tests/integration/opus.ts
+++ b/tests/integration/opus.ts
@@ -125,7 +125,7 @@ describe('Opus', function() {
       });
 
       it('should hang up', (done) => {
-        connection1.once('disconnected', () => done());
+        connection1.once('disconnect', () => done());
         connection2.disconnect();
       });
     });

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -89,18 +89,21 @@ describe('Device', function() {
     });
 
     it('should set enableIceRestart to false by default', () => {
-      const conn = device.setup(token, setupOptions);
-      assert.equal(conn['options'].enableIceRestart, false);
+      device.setup(token, setupOptions);
+      device.connect();
+      assert.equal((connectOptions as any).enableIceRestart, false);
     });
 
     it('should set enableIceRestart to false if passed in as false', () => {
-      const conn = device.setup(token, Object.assign({ enableIceRestart: false}, setupOptions));
-      assert.equal(conn['options'].enableIceRestart, false);
+      device.setup(token, Object.assign({ enableIceRestart: false}, setupOptions));
+      device.connect();
+      assert.equal((connectOptions as any).enableIceRestart, false);
     });
 
     it('should set enableIceRestart to false if passed in as true', () => {
-      const conn = device.setup(token, Object.assign({ enableIceRestart: true}, setupOptions));
-      assert.equal(conn['options'].enableIceRestart, true);
+      device.setup(token, Object.assign({ enableIceRestart: true}, setupOptions));
+      device.connect();
+      assert.equal((connectOptions as any).enableIceRestart, true);
     });
   });
 
@@ -769,8 +772,16 @@ describe('Device', function() {
       });
 
       describe('on connection.disconnected', () => {
-        it('should emit Device.disconnect', () => {
-          device.connections[0].emit('disconnected');
+        it('should emit Device.disconnect if ice restart is disabled', () => {
+          device.setup(token, Object.assign({ enableIceRestart: false}, setupOptions));
+          device.connect().emit('disconnect');
+          sinon.assert.calledOnce(device.emit as any);
+          sinon.assert.calledWith(device.emit as any, 'disconnect');
+        });
+
+        it('should emit Device.disconnect if ice restart is enabled', () => {
+          device.setup(token, Object.assign({ enableIceRestart: true}, setupOptions));
+          device.connect().emit('disconnect');
           sinon.assert.calledOnce(device.emit as any);
           sinon.assert.calledWith(device.emit as any, 'disconnect');
         });
@@ -781,7 +792,7 @@ describe('Device', function() {
           assert.equal(typeof conn, 'object');
           assert.equal(conn, device.activeConnection());
 
-          device.connections[0].emit('disconnected');
+          device.connections[0].emit('disconnect');
           assert.equal(typeof device.activeConnection(), 'undefined');
         });
       });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6284](https://issues.corp.twilio.com/browse/CLIENT-6284)

### Description

This PR is submitted against the ReconnectionState API branch (CLIENT-6284-ReconnectionState-1.8) that we merged in for 2.0. This PR is making use of the enableIceRestart flag and making sure we don't deprecate old events and methods. Once this is merged in, I'll update changelog and FRD and I'll submit a PR. Then we can merge the whole ReconnectionState API branch to master.
- put back Connection.status()
  - returns 'open' if state is connected
  - returns 'closed' if state is disconnected
- put back Connection.on('disconnect')
- put back Connection.on('ringing', handler(hasEarlyMedia))

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
