### PR TITLE
CLIENT-6284 | Adding reconnecting and reconnected events 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,9 @@ New Features
 This feature, when `enableIceRestart` is enabled, allows for detecting when media connection fails which will trigger automatic media reconnection, and for detecting when media connection is restored.
 
 #### New Events
-* `Connection.on('reconnecting', handler(connection, error))` - raised when media connection fails and automatic reconnection has been started. Media connection failure triggers when there is no media flowing for approximately more than 3 seconds. During this period, `Connection.status()` will be set to `reconnecting`;
-  * Parameters passed to the handler
-    * `connection` - the current connection object
-    * `error` - Error object `{ code: 53405, message: 'Media connection failed.' }`
-* `Connection.on('reconnected', handler(connection))` - raised when media connection has been restored which is detected when media starts flowing. Once reconnected, `Connection.status()` will be set to `open`;
-  * Parameters passed to the handler
-    * `connection` - the current connection object
+* `Connection.on('reconnecting', handler(error))` - raised when media connection fails and automatic reconnection has been started. Media connection failure triggers when there is no media flowing for approximately more than 3 seconds. During this period, `Connection.status()` will be set to `reconnecting`;
+  * `error` - Error object `{ code: 53405, message: 'Media connection failed.' }`
+* `Connection.on('reconnected', handler())` - raised when media connection has been restored which is detected when media starts flowing. Once reconnected, `Connection.status()` will be set to `open`;
 
 
 1.7.6 (In Progress)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+1.8.0 (In Progress)
+====================
+New Features
+------------
+### Media Reconnection States and Events
+This feature, when `enableIceRestart` is enabled, allows for detecting when media connection fails which will trigger automatic media reconnection, and for detecting when media connection is restored.
+
+#### New Events
+* `Connection.on('reconnecting', handler(connection, error))` - raised when media connection fails and automatic reconnection has been started. Media connection failure triggers when there is no media flowing for approximately more than 3 seconds. During this period, `Connection.status()` will be set to `reconnecting`;
+  * Parameters passed to the handler
+    * `connection` - the current connection object
+    * `error` - Error object `{ code: 53405, message: 'Media connection failed.' }`
+* `Connection.on('reconnected', handler(connection))` - raised when media connection has been restored which is detected when media starts flowing. Once reconnected, `Connection.status()` will be set to `open`;
+  * Parameters passed to the handler
+    * `connection` - the current connection object
+
+
 1.7.6 (In Progress)
 ====================
 New Features

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -268,7 +268,8 @@ class Connection extends EventEmitter {
 
     monitor.on('warning', (data: RTCWarning, wasCleared?: boolean) => {
       const { samples, name } = data;
-      if (this.options.enableIceRestart && (name === 'bytesSent' || name === 'bytesReceived')) {
+      if (this.options.enableIceRestart && this._status === Connection.State.Open
+        && (name === 'bytesSent' || name === 'bytesReceived')) {
 
         if (samples && samples.every(sample => sample.totals[name] === 0)) {
           // We don't have relevant samples yet, usually at the start of a call.
@@ -276,10 +277,14 @@ class Connection extends EventEmitter {
           return;
         }
 
-        this._log.warn('ICE Connection disconnected.');
-        // Stop existing loops if this warning is emitted multiple times
-        this._stopIceRestarts();
+        const mediaFailedError = { code: 53405, message: 'Media connection failed.' };
 
+        this._log.warn('ICE Connection disconnected.');
+        this._publisher.info('connection', 'reconnecting', null, this);
+        this._publisher.warn('connection', 'error', mediaFailedError, this);
+
+        this._stopIceRestarts();
+        this._status = Connection.State.Reconnecting;
         this._iceRestartIntervalId = setInterval(() => {
           this.mediaStream.iceRestart().catch((canRetry: boolean) => {
             if (!canRetry) {
@@ -288,12 +293,14 @@ class Connection extends EventEmitter {
             }
           });
         }, ICE_RESTART_INTERVAL);
+
+        this.emit('reconnecting', this, mediaFailedError);
       }
       this._reemitWarning(data, wasCleared);
     });
     monitor.on('warning-cleared', (data: RTCWarning) => {
       const { samples, name } = data;
-      if (name === 'bytesSent' || name === 'bytesReceived') {
+      if (this.options.enableIceRestart && (name === 'bytesSent' || name === 'bytesReceived')) {
 
         if (samples && samples.every(sample => sample.totals[name] === 0)) {
           // We don't have relevant samples yet, usually at the start of a call.
@@ -302,7 +309,11 @@ class Connection extends EventEmitter {
         }
 
         this._log.info('ICE Connection reestablished.');
+        this._publisher.info('connection', 'reconnected', null, this);
         this._stopIceRestarts();
+
+        this._status = Connection.State.Open;
+        this.emit('reconnected', this);
       }
       this._reemitWarningCleared(data);
     });
@@ -393,7 +404,7 @@ class Connection extends EventEmitter {
       // for _status 'open', we'd accidentally close the PeerConnection.
       //
       // See <https://code.google.com/p/webrtc/issues/detail?id=4996>.
-      if (this._status === Connection.State.Open) {
+      if (this._status === Connection.State.Open || this._status === Connection.State.Reconnecting) {
         return;
       } else if (this._status === Connection.State.Ringing || this._status === Connection.State.Connecting) {
         this.mute(false);
@@ -987,6 +998,7 @@ class Connection extends EventEmitter {
 
     if (this._status !== Connection.State.Open
         && this._status !== Connection.State.Connecting
+        && this._status !== Connection.State.Reconnecting
         && this._status !== Connection.State.Ringing) {
       return;
     }
@@ -1327,6 +1339,7 @@ namespace Connection {
     Connecting = 'connecting',
     Open = 'open',
     Pending = 'pending',
+    Reconnecting = 'reconnecting',
     Ringing = 'ringing',
   }
 

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -280,8 +280,8 @@ class Connection extends EventEmitter {
         const mediaFailedError = { code: 53405, message: 'Media connection failed.' };
 
         this._log.warn('ICE Connection disconnected.');
-        this._publisher.info('connection', 'reconnecting', null, this);
         this._publisher.warn('connection', 'error', mediaFailedError, this);
+        this._publisher.info('connection', 'reconnecting', null, this);
 
         this._stopIceRestarts();
         this._status = Connection.State.Reconnecting;
@@ -294,7 +294,7 @@ class Connection extends EventEmitter {
           });
         }, ICE_RESTART_INTERVAL);
 
-        this.emit('reconnecting', this, mediaFailedError);
+        this.emit('reconnecting', mediaFailedError);
       }
       this._reemitWarning(data, wasCleared);
     });
@@ -313,7 +313,7 @@ class Connection extends EventEmitter {
         this._stopIceRestarts();
 
         this._status = Connection.State.Open;
-        this.emit('reconnected', this);
+        this.emit('reconnected');
       }
       this._reemitWarningCleared(data);
     });

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -784,6 +784,7 @@ class Device extends EventEmitter {
   private _createDefaultPayload = (connection?: Connection): Record<string, any> => {
     const payload: Record<string, any> = {
       dscp: !!this.options.dscp,
+      ice_restart_enabled: this.options.enableIceRestart,
       platform: rtc.getMediaEngine(),
       sdk_version: C.RELEASE_VERSION,
       selected_region: this.options.region,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-client",
-  "version": "1.7.6-dev",
+  "version": "1.8.0-dev",
   "description": "Javascript SDK for Twilio Client",
   "main": "./es5/twilio.js",
   "license": "Apache-2.0",

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -1471,7 +1471,7 @@ describe('Connection', function() {
         clock.tick(7000);
         clock.restore();
         return wait().then(() => {
-          assert(callback.calledWithExactly(conn, { code: 53405, message: 'Media connection failed.' }));
+          assert(callback.calledWithExactly({ code: 53405, message: 'Media connection failed.' }));
         });
       });
       it('should change status to reconnecting', () => {
@@ -1537,7 +1537,7 @@ describe('Connection', function() {
         clock.tick(4000);
         clock.restore();
         return wait().then(() => {
-          assert(callback.calledWithExactly(conn));
+          assert(callback.calledOnce);
         });
       });
       it('should change status to open', () => {

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -1401,14 +1401,23 @@ describe('Connection', function() {
 
   describe('on monitor.warning', () => {
     context('if warningData.name contains bytes', () => {
+      const wait = () => new Promise(r => setTimeout(r, 0));
       beforeEach(() => {
         mediaStream.iceRestart = sinon.stub().returns({catch: () => {}});
+        (conn as any)['_status'] = Connection.State.Open;
       });
 
       it('should not start iceRestart loop if enableIceRestart is false', () => {
         conn = new Connection(config, Object.assign(options, { enableIceRestart: false }));
         monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'min' } });
         clock.tick(7000);
+        sinon.assert.callCount(mediaStream.iceRestart, 0);
+      });
+      it('should not start iceRestart loop if current status is not open', () => {
+        conn = new Connection(config, Object.assign(options, { enableIceRestart: true }));
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'min' } });
+        clock.tick(7000);
+        assert.notEqual(conn.status(), 'open');
         sinon.assert.callCount(mediaStream.iceRestart, 0);
       });
       it('should start iceRestart loop if enableIceRestart is true', () => {
@@ -1448,13 +1457,27 @@ describe('Connection', function() {
         clock.tick(3000);
         assert(mediaStream.iceRestart.calledOnce);
       });
-
       it('should stop iceRestart loop on mediaStream close', () => {
         monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'min' } });
         clock.tick(3000);
         mediaStream.onclose();
         clock.tick(3000);
         assert(mediaStream.iceRestart.calledOnce);
+      });
+      it('should raise reconnecting event', () => {
+        const callback = sinon.stub();
+        conn.on('reconnecting', callback);
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'min' } });
+        clock.tick(7000);
+        clock.restore();
+        return wait().then(() => {
+          assert(callback.calledWithExactly(conn, { code: 53405, message: 'Media connection failed.' }));
+        });
+      });
+      it('should change status to reconnecting', () => {
+        monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'min' } });
+        clock.tick(7000);
+        assert.equal(conn.status(), Connection.State.Reconnecting);
       });
     });
 
@@ -1485,10 +1508,12 @@ describe('Connection', function() {
 
   describe('on monitor.warning-cleared', () => {
     context('if warningData.name contains bytes', () => {
+      const wait = () => new Promise(r => setTimeout(r, 0));
       beforeEach(() => {
         mediaStream.iceRestart = sinon.stub().returns({catch: () => {}});
       });
       it('should stop iceRestart loop for bytesReceived', () => {
+        (conn as any)['_status'] = Connection.State.Open;
         monitor.emit('warning', { name: 'bytesReceived', threshold: { name: 'min' } });
         clock.tick(4000);
         monitor.emit('warning-cleared', { name: 'bytesReceived', threshold: { name: 'min' } });
@@ -1496,11 +1521,31 @@ describe('Connection', function() {
         assert(mediaStream.iceRestart.calledOnce);
       });
       it('should stop iceRestart loop for bytesSent', () => {
+        (conn as any)['_status'] = Connection.State.Open;
         monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'min' } });
         clock.tick(4000);
         monitor.emit('warning-cleared', { name: 'bytesSent', threshold: { name: 'min' } });
         clock.tick(4000);
         assert(mediaStream.iceRestart.calledOnce);
+      });
+      it('should raise reconnected event', () => {
+        const callback = sinon.stub();
+        conn.on('reconnected', callback);
+        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'min' } });
+        clock.tick(4000);
+        monitor.emit('warning-cleared', { name: 'bytesSent', threshold: { name: 'min' } });
+        clock.tick(4000);
+        clock.restore();
+        return wait().then(() => {
+          assert(callback.calledWithExactly(conn));
+        });
+      });
+      it('should change status to open', () => {
+        monitor.emit('warning', { name: 'bytesSent', threshold: { name: 'min' } });
+        clock.tick(4000);
+        monitor.emit('warning-cleared', { name: 'bytesSent', threshold: { name: 'min' } });
+        clock.tick(4000);
+        assert.equal(conn.status(), Connection.State.Open);
       });
     });
     context('if warningData.name contains audio', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6284](https://issues.corp.twilio.com/browse/CLIENT-6284)

### Description

- Add new `reconnecting` event on transition to new `reconnecting` state
- Add new `reconnected` event on transition from `reconnecting` to `open`
- Publishing events to insights on reconnection and on reconnected
- Adding ice_restart_enabled on insights default payload

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
