### PR TITLE
Switch maxBitrate to use maxaveragebitrate via SDP munging

### DIFF
--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -1606,7 +1606,8 @@ namespace Connection {
 
     /**
      * Max bitrate, in bits per second, for the local audio stream. Only works with Opus as
-     * this parameter is not supported by PCMU, which has a fixed birtate.
+     * this parameter is not supported by PCMU, which has a fixed bitrate. The minimum
+     * bitrate supported by Opus is 6kbit/s.
      */
     maxBitrate?: number;
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1431,7 +1431,8 @@ namespace Device {
 
     /**
      * Max bitrate, in bits per second, for the local audio stream. Only works with Opus as
-     * this parameter is not supported by PCMU, which has a fixed birtate.
+     * this parameter is not supported by PCMU, which has a fixed bitrate. The minimum
+     * bitrate supported by Opus is 6kbit/s.
      */
     maxBitrate?: number;
 

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -297,7 +297,7 @@ PeerConnection.prototype._setInputTracksForPlanB = function(shouldClone, newStre
   }
 
   return new Promise((resolve, reject) => {
-    this.version.createOffer(this.codecPreferences, { audio: true }, () => {
+    this.version.createOffer(this.options.maxBitrate, this.codecPreferences, { audio: true }, () => {
       this.version.processAnswer(this.codecPreferences, this._answerSdp, () => {
         resolve(this.stream);
       }, reject);
@@ -563,7 +563,7 @@ PeerConnection.prototype._fallbackOnAddTrack = function fallbackOnAddTrack(pc, s
   });
 };
 
-PeerConnection.prototype._setEncodingParameters = function(enableDscp, maxBitrate) {
+PeerConnection.prototype._setEncodingParameters = function(enableDscp) {
   if (!this._sender
       || typeof this._sender.getParameters !== 'function'
       || typeof this._sender.setParameters !== 'function') {
@@ -583,12 +583,6 @@ PeerConnection.prototype._setEncodingParameters = function(enableDscp, maxBitrat
     params.encodings.forEach(encoding => {
       encoding.priority = 'high';
       encoding.networkPriority = 'high';
-    });
-  }
-
-  if (typeof maxBitrate === 'number') {
-    params.encodings.forEach(encoding => {
-      encoding.maxBitrate = maxBitrate;
     });
   }
 
@@ -710,7 +704,7 @@ PeerConnection.prototype.iceRestart = function() {
     return;
   }
   this.log('Attempting to restart ICE...');
-  this.version.createOffer(this.codecPreferences, { iceRestart: true }).then(() => {
+  this.version.createOffer(this.options.maxBitrate, this.codecPreferences, { iceRestart: true }).then(() => {
     this._removeReconnectionListeners();
 
     this._onAnswerOrRinging = payload => {
@@ -759,7 +753,7 @@ PeerConnection.prototype.makeOutgoingCall = function(token, params, callsid, rtc
   this.callSid = callsid;
   function onAnswerSuccess() {
     if (self.options) {
-      self._setEncodingParameters(self.options.dscp, self.options.maxBitrate);
+      self._setEncodingParameters(self.options.dscp);
     }
     onMediaStarted(self.version.pc);
   }
@@ -803,7 +797,7 @@ PeerConnection.prototype.makeOutgoingCall = function(token, params, callsid, rtc
     } });
   }
 
-  this.version.createOffer(this.codecPreferences, { audio: true }, onOfferSuccess, onOfferError);
+  this.version.createOffer(this.options.maxBitrate, this.codecPreferences, { audio: true }, onOfferSuccess, onOfferError);
 };
 PeerConnection.prototype.answerIncomingCall = function(callSid, sdp, rtcConstraints, rtcConfiguration, onMediaStarted) {
   if (!this._initializeMediaStream(rtcConstraints, rtcConfiguration)) {
@@ -819,7 +813,7 @@ PeerConnection.prototype.answerIncomingCall = function(callSid, sdp, rtcConstrai
         sdp: self.version.getSDP()
       });
       if (self.options) {
-        self._setEncodingParameters(self.options.dscp, self.options.maxBitrate);
+        self._setEncodingParameters(self.options.dscp);
       }
       onMediaStarted(self.version.pc);
     }

--- a/lib/twilio/rtc/rtcpc.js
+++ b/lib/twilio/rtc/rtcpc.js
@@ -1,6 +1,6 @@
 /* global webkitRTCPeerConnection, mozRTCPeerConnection, mozRTCSessionDescription, mozRTCIceCandidate */
 const RTCPeerConnectionShim = require('rtcpeerconnection-shim');
-const { setCodecPreferences } = require('./sdp');
+const { setCodecPreferences, setMaxBitrate } = require('./sdp');
 const util = require('../util');
 
 function RTCPC() {
@@ -65,14 +65,18 @@ RTCPC.prototype.createModernConstraints = c => {
 
   return nc;
 };
-RTCPC.prototype.createOffer = function(codecPreferences, constraints, onSuccess, onError) {
+RTCPC.prototype.createOffer = function(maxBitrate, codecPreferences, constraints, onSuccess, onError) {
   constraints = this.createModernConstraints(constraints);
   return promisifyCreate(this.pc.createOffer, this.pc)(constraints).then(offer => {
     if (!this.pc) { return Promise.resolve(); }
 
+    const sdp = maxBitrate
+      ? setMaxBitrate(offer.sdp, maxBitrate)
+      : offer.sdp;
+
     return promisifySet(this.pc.setLocalDescription, this.pc)(new RTCSessionDescription({
       type: 'offer',
-      sdp: setCodecPreferences(offer.sdp, codecPreferences),
+      sdp: setCodecPreferences(sdp, codecPreferences),
     }));
   }).then(onSuccess, onError);
 };

--- a/lib/twilio/rtc/sdp.js
+++ b/lib/twilio/rtc/sdp.js
@@ -5,6 +5,19 @@ const ptToFixedBitrateAudioCodecName = {
   8: 'PCMA'
 };
 
+const defaultOpusId = 111;
+
+function setMaxBitrate(sdp, maxBitrate) {
+  const matches = /a=rtpmap:(\d+) opus/gm.exec(sdp);
+  const opusId = matches && matches.length ? matches[1] : defaultOpusId;
+  const regex = new RegExp(`a=fmtp:${opusId}`);
+  const lines = sdp.split('\n').map(line => regex.test(line)
+    ? line + `;maxaveragebitrate=${maxBitrate}`
+    : line);
+
+  return lines.join('\n');
+}
+
 /**
  * Return a new SDP string with the re-ordered codec preferences.
  * @param {string} sdp
@@ -137,4 +150,4 @@ function getPayloadTypesInMediaSection(section) {
   return matches.slice(1).map(match => parseInt(match, 10));
 }
 
-module.exports = { setCodecPreferences };
+module.exports = { setCodecPreferences, setMaxBitrate };

--- a/tests/sdp.js
+++ b/tests/sdp.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 
-const { setCodecPreferences } = require('../lib/twilio/rtc/sdp');
+const { setCodecPreferences, setMaxBitrate } = require('../lib/twilio/rtc/sdp');
 
 const { makeSdpWithTracks } = require('./lib/mocksdp');
 const { combinationContext } = require('./lib/util');
@@ -25,6 +25,20 @@ describe('setCodecPreferences', () => {
         : ['109', '9', '0', '8', '101'];
       itShouldHaveCodecOrder(sdpType, preferredCodecs, expectedCodecIds);
     });
+  });
+});
+
+describe('setMaxBitrate', () => {
+  it('should set the maxaveragebitrate if opus rtpmap line is not found ', () => {
+    const sdp = 'foo=a\na=rtpmap:0 PCMU/8000\na=fmtp:111\nbar=b';
+    const newSdp = setMaxBitrate(sdp, 12345);
+    assert.equal(newSdp, 'foo=a\na=rtpmap:0 PCMU/8000\na=fmtp:111;maxaveragebitrate=12345\nbar=b');
+  });
+
+  it('should set the maxaveragebitrate if opus rtpmap line is found ', () => {
+    const sdp = 'foo=a\na=rtpmap:0 PCMU/8000\na=rtpmap:1337 opus/48000/2\na=fmtp:1337\nbar=b';
+    const newSdp = setMaxBitrate(sdp, 12345);
+    assert.equal(newSdp, 'foo=a\na=rtpmap:0 PCMU/8000\na=rtpmap:1337 opus/48000/2\na=fmtp:1337;maxaveragebitrate=12345\nbar=b');
   });
 });
 


### PR DESCRIPTION
New description:
This implements the `maxaveragebitrate` approach of applying maxBitrate by munging the SDP. This negotiates a bitrate to use at both ends of the call, and is no longer limited to only the outgoing bitrate.

Original description:
> https://issues.corp.twilio.com/browse/CLIENT-5589
> 
> Apparently lower bound on Opus is 6kpbs and Chrome limits to over 12kpbs. So if a customer passes lower than 6kpbs they get an error and under 12kpbs it is silently ignored. Added a check for under 12001 and set minimum to 12001.
> 
> Also added a check for PCMU being set because we get an error if we try to set a bitrate for PCMU.