### PR TITLE
CLIENT-6539 | Getting audio levels and add insights for extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+1.8.1 (In Progress)
+====================
+
+Bug Fixes
+---------
+
+* Fixed an issue where audio levels reported are zero when running as an extension, or when the browser tab is inactive or minimized.
+
+
 1.8.0 (Aug 20, 2019)
 ====================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Bug Fixes
 ---------
 
-* Fixed an issue where audio levels reported are zero when running as an extension, or when the browser tab is inactive or minimized.
+* Fixed an issue causing audio levels to be reported as zero when running as an extension, or when the browser tab is inactive or minimized.
 
 
 1.8.0 (Aug 20, 2019)

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -1380,10 +1380,8 @@ namespace Connection {
   declare function rejectEvent(connection: Connection): void;
 
   /**
-   * Emitted on `requestAnimationFrame` (up to 60fps, depending on browser) with
-   *   the current input and output volumes, as a percentage of maximum
-   *   volume, between -100dB and -30dB. Represented by a floating point
-   *   number.
+   * Emitted up to 20hz with the current input and output volumes, as a percentage of maximum
+   * volume, between -100dB and -30dB. Represented by a floating point number.
    * @param inputVolume - A floating point number between 0.0 and 1.0 inclusive.
    * @param outputVolume - A floating point number between 0.0 and 1.0 inclusive.
    * @example `connection.on('volume', (inputVolume, outputVolume) => { })`

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -1380,7 +1380,7 @@ namespace Connection {
   declare function rejectEvent(connection: Connection): void;
 
   /**
-   * Emitted up to 20hz with the current input and output volumes, as a percentage of maximum
+   * Emitted every 50ms with the current input and output volumes, as a percentage of maximum
    * volume, between -100dB and -30dB. Represented by a floating point number.
    * @param inputVolume - A floating point number between 0.0 and 1.0 inclusive.
    * @param outputVolume - A floating point number between 0.0 and 1.0 inclusive.

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -370,8 +370,14 @@ class Device extends EventEmitter {
 
     if (window) {
       const root: any = window as any;
-      const browser: any = root.chrome || root.browser || root.msBrowser;
-      this._isBrowserExtension = !!browser && !!browser.runtime && !!browser.runtime.id;
+      const browser: any = root.msBrowser || root.browser || root.chrome;
+
+      this._isBrowserExtension = (!!browser && !!browser.runtime && !!browser.runtime.id)
+        || (!!root.safari && !!root.safari.extension);
+    }
+
+    if (this._isBrowserExtension) {
+      this._log.info('Running as browser extension.');
     }
 
     if (token) {

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -278,6 +278,11 @@ class Device extends EventEmitter {
   };
 
   /**
+   * Whether SDK is run as a browser extension
+   */
+  private _isBrowserExtension: boolean;
+
+  /**
    * An instance of Log to use.
    */
   private _log: Log = new Log(LogLevel.Off);
@@ -362,6 +367,12 @@ class Device extends EventEmitter {
   constructor(token: string, options?: Device.Options);
   constructor(token?: string, options?: Device.Options) {
     super();
+
+    if (window) {
+      const root: any = window as any;
+      const browser: any = root.chrome || root.browser || root.msBrowser;
+      this._isBrowserExtension = !!browser && !!browser.runtime && !!browser.runtime.id;
+    }
 
     if (token) {
       this.setup(token, options);
@@ -797,6 +808,7 @@ class Device extends EventEmitter {
    */
   private _createDefaultPayload = (connection?: Connection): Record<string, any> => {
     const payload: Record<string, any> = {
+      browser_extension: this._isBrowserExtension,
       dscp: !!this.options.dscp,
       ice_restart_enabled: this.options.enableIceRestart,
       platform: rtc.getMediaEngine(),

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -8,8 +8,7 @@ const Log = require('../log');
 const util = require('../util');
 const RTCPC = require('./rtcpc');
 
-// 20hz
-const EMIT_VOLUME_TIMEOUT = 50;
+const VOLUME_INTERVAL_MS = 50;
 const INITIAL_ICE_CONNECTION_STATE = 'new';
 
 /**
@@ -183,8 +182,8 @@ PeerConnection.prototype._startPollingVolume = function() {
     const outputVolume2 = self.util.average(outputDataArray);
     self.onvolume(inputVolume / 255, outputVolume / 255, inputVolume2, outputVolume2);
 
-    setTimeout(emitVolume, EMIT_VOLUME_TIMEOUT);
-  }, EMIT_VOLUME_TIMEOUT);
+    setTimeout(emitVolume, VOLUME_INTERVAL_MS);
+  }, VOLUME_INTERVAL_MS);
 };
 
 PeerConnection.prototype._stopStream = function _stopStream(stream) {

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -8,6 +8,8 @@ const Log = require('../log');
 const util = require('../util');
 const RTCPC = require('./rtcpc');
 
+// 20hz
+const EMIT_VOLUME_TIMEOUT = 50;
 const INITIAL_ICE_CONNECTION_STATE = 'new';
 
 /**
@@ -157,7 +159,7 @@ PeerConnection.prototype._startPollingVolume = function() {
   this._updateOutputStreamSource(this._remoteStream);
 
   const self = this;
-  requestAnimationFrame(function emitVolume() {
+  setTimeout(function emitVolume() {
     if (!self._audioContext) {
       return;
     } else if (self.status === 'closed') {
@@ -181,8 +183,8 @@ PeerConnection.prototype._startPollingVolume = function() {
     const outputVolume2 = self.util.average(outputDataArray);
     self.onvolume(inputVolume / 255, outputVolume / 255, inputVolume2, outputVolume2);
 
-    requestAnimationFrame(emitVolume);
-  });
+    setTimeout(emitVolume, EMIT_VOLUME_TIMEOUT);
+  }, EMIT_VOLUME_TIMEOUT);
 };
 
 PeerConnection.prototype._stopStream = function _stopStream(stream) {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6539](https://issues.corp.twilio.com/browse/CLIENT-6539)

### Description

- Get audio levels without relying on requestAnimationFrame which won't trigger when a tab is inactive or when running as an extension.
- Adding insights whether running as an extension.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
