### PR TITLE
CLIENT-6581 | Dont use RTCPC singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Device.setup(TOKEN, {
 });
 ```
 
+Bug Fixes
+---------
+
+* Fixed an issue causing multiple devices that are created in the same tab to get disconnected when one of the devices disconnects a connection. (CLIENT-6581)
+
+
 1.8.1 (Aug 28, 2019)
 ====================
 

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -593,7 +593,7 @@ PeerConnection.prototype._setEncodingParameters = function(enableDscp) {
 
 PeerConnection.prototype._setupPeerConnection = function(rtcConstraints, rtcConfiguration) {
   const self = this;
-  const version = this._getProtocol();
+  const version = new (this.options.rtcpcFactory || RTCPC)();
   version.create(this.log, rtcConstraints, rtcConfiguration);
   addStream(version.pc, this.stream);
 
@@ -947,8 +947,7 @@ PeerConnection.prototype._canStopMediaStreamTrack = () => typeof MediaStreamTrac
 PeerConnection.prototype._getAudioTracks = stream => typeof stream.getAudioTracks === 'function' ?
   stream.getAudioTracks() : stream.audioTracks;
 
-PeerConnection.prototype._getProtocol = () => PeerConnection.protocol;
-
+// Is PeerConnection.protocol used outside of our SDK? We should remove this if not.
 PeerConnection.protocol = ((() => RTCPC.test() ? new RTCPC() : null))();
 
 function addStream(pc, stream) {
@@ -1002,6 +1001,6 @@ function setAudioSource(audio, stream) {
   return true;
 }
 
-PeerConnection.enabled = !!PeerConnection.protocol;
+PeerConnection.enabled = RTCPC.test();
 
 module.exports = PeerConnection;

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -1796,11 +1796,18 @@ describe('PeerConnection', () => {
     const MESSAGE = 'error message';
     const ERROR = new Error(MESSAGE);
 
+    const rtcpcFactory = function() {
+      this.create = versionCreate;
+      this.pc = versionPc;
+    };
+
     let toTest = null;
     let context = null;
     let params = null;
     let sender = null;
-    let version = null;
+
+    let versionCreate;
+    let versionPc;
 
     beforeEach(() => {
       params = {
@@ -1814,54 +1821,58 @@ describe('PeerConnection', () => {
         getParameters: sinon.spy(() => Object.assign({ }, params)),
         setParameters: sinon.spy((p) => params = p),
       };
-      version = {
-        create: sinon.stub(),
-        pc: {
-          addStream: sinon.stub(),
-          getSenders: () => [sender],
-        }
+      versionCreate = sinon.stub();
+      versionPc = {
+        addStream: sinon.stub(),
+        getSenders: () => [sender],
       };
       context = {
         _isSinkSupported: true,
-        options: { },
+        options: {
+          rtcpcFactory
+        },
         stream: STREAM,
         log: LOG,
         _onAddTrack: sinon.stub(),
         _fallbackOnAddTrack: sinon.stub(),
         _startPollingVolume: sinon.stub(),
-        _getProtocol: sinon.stub().returns(version),
       };
       toTest = METHOD.bind(context, CONSTRAINTS, ICE_SERVERS);
     });
 
+    it('Should create new version everytime', () => {
+      // Make sure a new reference is created each time
+      assert(toTest() !== toTest());
+    });
+
     it('Should set callback on version pc onaddstream when create and addstream do not throw error', () => {
-      assert.deepStrictEqual(toTest(), version);
-      assert(version.create.calledWithExactly(LOG, CONSTRAINTS, ICE_SERVERS));
-      assert(version.pc.addStream.calledWithExactly(STREAM));
-      assert.equal(typeof version.pc.onaddstream, 'function');
+      assert.deepStrictEqual(toTest(), new rtcpcFactory());
+      assert(versionCreate.calledWithExactly(LOG, CONSTRAINTS, ICE_SERVERS));
+      assert(versionPc.addStream.calledWithExactly(STREAM));
+      assert.equal(typeof versionPc.onaddstream, 'function');
     });
 
     it('Should not create onaddstream callback function when version create throws error', () => {
-      version.create.throws(ERROR);
+      versionCreate.throws(ERROR);
       assert.throws(toTest, MESSAGE);
-      assert(version.create.calledWithExactly(LOG, CONSTRAINTS, ICE_SERVERS));
-      assert.equal(version.pc.addStream.called, false);
-      assert.equal(typeof version.pc.onaddstream, 'undefined');
+      assert(versionCreate.calledWithExactly(LOG, CONSTRAINTS, ICE_SERVERS));
+      assert.equal(versionPc.addStream.called, false);
+      assert.equal(typeof versionPc.onaddstream, 'undefined');
     });
 
     it('Should not create onaddstream callback function when pc addstream throws error', () => {
-      version.pc.addStream.throws(ERROR);
+      versionPc.addStream.throws(ERROR);
       assert.throws(toTest, MESSAGE);
-      assert(version.create.calledWithExactly(LOG, CONSTRAINTS, ICE_SERVERS));
-      assert(version.pc.addStream.calledWithExactly(STREAM));
-      assert.equal(typeof version.pc.onaddstream, 'undefined');
+      assert(versionCreate.calledWithExactly(LOG, CONSTRAINTS, ICE_SERVERS));
+      assert(versionPc.addStream.calledWithExactly(STREAM));
+      assert.equal(typeof versionPc.onaddstream, 'undefined');
     });
 
     it('Should call _onAddTrack when sink is supported', () => {
       const event = {stream: STREAM};
-      assert.deepStrictEqual(toTest(), version);
-      version.pc.onaddstream({stream: STREAM});
-      assert.equal(typeof version.pc.onaddstream, 'function');
+      assert.deepStrictEqual(toTest(), new rtcpcFactory());
+      versionPc.onaddstream({stream: STREAM});
+      assert.equal(typeof versionPc.onaddstream, 'function');
       assert.equal(context._remoteStream, STREAM);
       assert(context._onAddTrack.calledWithExactly(context, STREAM));
       assert.equal(context._fallbackOnAddTrack.called, false);
@@ -1872,9 +1883,9 @@ describe('PeerConnection', () => {
     it('Should call _onAddTrack when sink is supported', () => {
       context._isSinkSupported = false;
       const event = {stream: STREAM};
-      assert.deepStrictEqual(toTest(), version);
-      version.pc.onaddstream({stream: STREAM});
-      assert.equal(typeof version.pc.onaddstream, 'function');
+      assert.deepStrictEqual(toTest(), new rtcpcFactory());
+      versionPc.onaddstream({stream: STREAM});
+      assert.equal(typeof versionPc.onaddstream, 'function');
       assert.equal(context._remoteStream, STREAM);
       assert(context._fallbackOnAddTrack.calledWithExactly(context, STREAM));
       assert(context._fallbackOnAddTrack.calledOn(context));
@@ -1923,7 +1934,6 @@ describe('PeerConnection', () => {
         _onAddTrack: sinon.stub(),
         _fallbackOnAddTrack: sinon.stub(),
         _startPollingVolume: sinon.stub(),
-        _getProtocol: sinon.stub().returns(version),
       };
       toTest = METHOD.bind(context, true);
     });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6581](https://issues.corp.twilio.com/browse/CLIENT-6581)

### Description

We are now creating a new instance of RTCPC for every PeerConnection.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
