### PR TITLE
Add the settings:codec event after remote answer is applied

### DIFF
--- a/lib/twilio/rtc/sdp.js
+++ b/lib/twilio/rtc/sdp.js
@@ -9,6 +9,13 @@ const defaultOpusId = 111;
 const BITRATE_MAX = 510000;
 const BITRATE_MIN = 6000;
 
+function getPreferredCodecInfo(sdp) {
+  const [, codecId, codecName] = /a=rtpmap:(\d+) (\S+)/m.exec(sdp) || [null, '', ''];
+  const regex = new RegExp(`a=fmtp:${codecId} (\\S+)`, 'm');
+  const [, codecParams] = regex.exec(sdp) || [null, ''];
+  return { codecName, codecParams };
+}
+
 function setMaxAverageBitrate(sdp, maxAverageBitrate) {
   if (typeof maxAverageBitrate !== 'number'
       || maxAverageBitrate < BITRATE_MIN
@@ -16,7 +23,7 @@ function setMaxAverageBitrate(sdp, maxAverageBitrate) {
     return sdp;
   }
 
-  const matches = /a=rtpmap:(\d+) opus/gm.exec(sdp);
+  const matches = /a=rtpmap:(\d+) opus/m.exec(sdp);
   const opusId = matches && matches.length ? matches[1] : defaultOpusId;
   const regex = new RegExp(`a=fmtp:${opusId}`);
   const lines = sdp.split('\n').map(line => regex.test(line)
@@ -158,4 +165,4 @@ function getPayloadTypesInMediaSection(section) {
   return matches.slice(1).map(match => parseInt(match, 10));
 }
 
-module.exports = { setCodecPreferences, setMaxAverageBitrate };
+module.exports = { getPreferredCodecInfo, setCodecPreferences, setMaxAverageBitrate };

--- a/tests/sdp.js
+++ b/tests/sdp.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 
-const { setCodecPreferences, setMaxAverageBitrate } = require('../lib/twilio/rtc/sdp');
+const { getPreferredCodecInfo, setCodecPreferences, setMaxAverageBitrate } = require('../lib/twilio/rtc/sdp');
 
 const { makeSdpWithTracks } = require('./lib/mocksdp');
 const { combinationContext } = require('./lib/util');
@@ -51,6 +51,15 @@ describe('setMaxAverageBitrate', () => {
     const sdp = 'foo=a\na=rtpmap:0 PCMU/8000\na=rtpmap:1337 opus/48000/2\na=fmtp:1337\nbar=b';
     const newSdp = setMaxAverageBitrate(sdp, 510001);
     assert.equal(newSdp, 'foo=a\na=rtpmap:0 PCMU/8000\na=rtpmap:1337 opus/48000/2\na=fmtp:1337\nbar=b');
+  });
+});
+
+describe('getPreferredCodecInfo', () => {
+  it('should get the correct info for Opus', () => {
+    const sdp = 'foo=a\na=rtpmap:1337 opus/48000/2\na=rtpmap:0 PCMU/8000\na=fmtp:0\na=fmtp:1337 maxaveragebitrate=12000;usedtx=0\nbar=b';
+    const { codecName, codecParams } = getPreferredCodecInfo(sdp);
+    assert.equal(codecName, 'opus/48000/2');
+    assert.equal(codecParams, 'maxaveragebitrate=12000;usedtx=0');
   });
 });
 

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -39,7 +39,8 @@ describe('Connection', function() {
     mediaStream._remoteStream = Symbol('_remoteStream');
     mediaStream.isMuted = Symbol('isMuted');
     mediaStream.mute = sinon.spy((shouldMute: boolean) => { mediaStream.isMuted = shouldMute; });
-    mediaStream.version = {pc: {}};
+    mediaStream.version = {pc: {}, getSDP: () => 
+      'a=rtpmap:1337 opus/48000/2\na=rtpmap:0 PCMU/8000\na=fmtp:0\na=fmtp:1337 maxaveragebitrate=12000'};
     return mediaStream;
   };
 
@@ -278,6 +279,17 @@ describe('Connection', function() {
             });
           });
 
+          it('should publish a settings:codec event', () => {
+            conn.accept();
+            return wait.then(() => {
+              callback('foo');
+              sinon.assert.calledWith(publisher.info, 'settings', 'codec', {
+                codec_params: 'maxaveragebitrate=12000',
+                selected_codec: 'opus/48000/2',
+              });
+            });
+          });
+
           it('should call monitor.enable', () => {
             conn.accept();
             return wait.then(() => {
@@ -337,6 +349,17 @@ describe('Connection', function() {
             return wait.then(() => {
               callback('foo');
               sinon.assert.calledWith(publisher.info, 'connection', 'accepted-by-remote');
+            });
+          });
+
+          it('should publish a settings:codec event', () => {
+            conn.accept();
+            return wait.then(() => {
+              callback('foo');
+              sinon.assert.calledWith(publisher.info, 'settings', 'codec', {
+                codec_params: 'maxaveragebitrate=12000',
+                selected_codec: 'opus/48000/2',
+              });
             });
           });
 


### PR DESCRIPTION
This adds the following event based off of the [mobile implementation](https://github.com/twilio/rtc-cpp/pull/1105):
```js
group: settings
name: codec
payload:
  codec_params: string // eg: 'maxaveragebitrate=12000;usedtx=1'
  selected_codec: string // eg: 'opus/48000/2'
```

If either or neither of the codec name or codec params are found, an empty string will be reported in its place.

This uses the SDP we get after applying the remote answer, for both incoming and outgoing calls.