### PR TITLE
CLIENT-6632 | Don't always download ringtones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.9.1 (In Progress)
+===================
+
+Improvements
+---------
+
+* Ringtone media files are now cached and downloaded once, on `Device.setup()`. (CLIENT-6632)
+
 1.9.0 (Sept 10, 2019)
 ===================
 

--- a/lib/twilio/sound.js
+++ b/lib/twilio/sound.js
@@ -37,7 +37,7 @@ function Sound(name, url, options) {
 
   Object.defineProperties(this, {
     _activeEls: {
-      value: new Set()
+      value: new Map()
     },
     _Audio: {
       value: options.AudioPlayer
@@ -80,20 +80,94 @@ function Sound(name, url, options) {
   });
 
   if (this._Audio) {
-    preload(this._Audio, url);
+    // Play it (muted and should not loop) as soon as possible so that it does not get incorrectly caught by Chrome's
+    // "gesture requirement for media playback" feature.
+    // https://plus.google.com/+FrancoisBeaufort/posts/6PiJQqJzGqX
+    this._play(true, false);
   }
 }
 
-function preload(AudioFactory, url) {
-  const el = new AudioFactory(url);
-  el.preload = 'auto';
-  el.muted = true;
-
-  // Play it (muted) as soon as possible so that it does not get incorrectly caught by Chrome's
-  // "gesture requirement for media playback" feature.
-  // https://plus.google.com/+FrancoisBeaufort/posts/6PiJQqJzGqX
-  el.play();
+function destroyAudioElement(audioElement) {
+  if (audioElement) {
+    audioElement.pause();
+    audioElement.src = '';
+    audioElement.srcObject = null;
+    audioElement.load();
+  }
 }
+
+/**
+ * Plays the audio element that was initialized using the speficied sinkId
+ */
+Sound.prototype._playAudioElement = function _playAudioElement(sinkId, isMuted, shouldLoop) {
+  const audioElement = this._activeEls.get(sinkId);
+
+  if (!audioElement) {
+    throw new InvalidArgumentError(`sinkId: "${sinkId}" doesn't have an audio element`);
+  }
+
+  audioElement.muted = isMuted;
+  audioElement.loop = shouldLoop;
+
+  return audioElement.play()
+    .then(() => audioElement)
+    .catch((reason) => {
+      destroyAudioElement(audioElement);
+      this._activeEls.delete(sinkId);
+      throw reason;
+    });
+};
+
+/**
+ * Start playing the sound. Will stop the currently playing sound first.
+ * If it exists, the audio element that was initialized for the sinkId will be used
+ */
+Sound.prototype._play = function _play(forceIsMuted, forceShouldLoop) {
+  if (this.isPlaying) {
+    this.stop();
+  }
+
+  if (this._maxDuration > 0) {
+    this._maxDurationTimeout = setTimeout(this.stop.bind(this), this._maxDuration);
+  }
+
+  forceShouldLoop = typeof forceShouldLoop === 'boolean' ? forceShouldLoop : this._shouldLoop;
+  const self = this;
+  const playPromise = this._playPromise = Promise.all(this._sinkIds.map(function createAudioElement(sinkId) {
+    if (!self._Audio) {
+      return Promise.resolve();
+    }
+
+    let audioElement = self._activeEls.get(sinkId);
+    if (audioElement) {
+      return self._playAudioElement(sinkId, forceIsMuted, forceShouldLoop);
+    }
+
+    audioElement = new self._Audio(self.url);
+
+    /**
+     * (rrowland) Bug in Chrome 53 & 54 prevents us from calling Audio.setSinkId without
+     *   crashing the tab. https://bugs.chromium.org/p/chromium/issues/detail?id=655342
+     */
+    return new Promise(resolve => {
+      audioElement.addEventListener('canplaythrough', resolve);
+    }).then(() => {
+      return (self._isSinkSupported
+          ? audioElement.setSinkId(sinkId)
+          : Promise.resolve()).then(function setSinkIdSuccess() {
+        self._activeEls.set(sinkId, audioElement);
+
+        // Stop has been called, bail out
+        if (!self._playPromise) {
+          return Promise.resolve();
+        }
+        return self._playAudioElement(sinkId, forceIsMuted, forceShouldLoop);
+      });
+    });
+  }));
+
+  return playPromise;
+};
 
 /**
  * Update the sinkIds of the audio output devices this sound should play through.
@@ -110,13 +184,16 @@ Sound.prototype.setSinkIds = function setSinkIds(ids) {
  * @return {void}
  */
 Sound.prototype.stop = function stop() {
-  this._activeEls.forEach(audioEl => {
-    audioEl.pause();
-    audioEl.src = '';
-    audioEl.load();
+  this._activeEls.forEach((audioEl, sinkId) => {
+    if (this._sinkIds.includes(sinkId)) {
+      audioEl.pause();
+      audioEl.currentTime = 0;
+    } else {
+      // Destroy the ones that are not used anymore
+      destroyAudioElement(audioEl);
+      this._activeEls.delete(sinkId);
+    }
   });
-
-  this._activeEls.clear();
 
   clearTimeout(this._maxDurationTimeout);
 
@@ -125,58 +202,10 @@ Sound.prototype.stop = function stop() {
 };
 
 /**
- * Start playing the sound. Will stop the currently playing sound first.
+ * Start playing the sound.
  */
 Sound.prototype.play = function play() {
-  if (this.isPlaying) {
-    this.stop();
-  }
-
-  if (this._maxDuration > 0) {
-    this._maxDurationTimeout = setTimeout(this.stop.bind(this), this._maxDuration);
-  }
-
-  const self = this;
-  const playPromise = this._playPromise = Promise.all(this._sinkIds.map(function createAudioElement(sinkId) {
-    if (!self._Audio) {
-      return Promise.resolve();
-    }
-
-    const audioElement = new self._Audio(self.url);
-    audioElement.loop = self._shouldLoop;
-
-    audioElement.addEventListener('ended', () => {
-      self._activeEls.delete(audioElement);
-    });
-
-    /**
-     * (rrowland) Bug in Chrome 53 & 54 prevents us from calling Audio.setSinkId without
-     *   crashing the tab. https://bugs.chromium.org/p/chromium/issues/detail?id=655342
-     */
-    return new Promise(resolve => {
-      audioElement.addEventListener('canplaythrough', resolve);
-    }).then(() => {
-      // If stop has already been called, or another play has been initiated,
-      // bail out before setting up the element to play.
-      if (!self.isPlaying || self._playPromise !== playPromise) {
-        return Promise.resolve();
-      }
-
-      return (self._isSinkSupported
-          ? audioElement.setSinkId(sinkId)
-          : Promise.resolve()).then(function setSinkIdSuccess() {
-        self._activeEls.add(audioElement);
-        return audioElement.play();
-      }).then(function playSuccess() {
-        return audioElement;
-      }, function playFailure(reason) {
-        self._activeEls.delete(audioElement);
-        throw reason;
-      });
-    });
-  }));
-
-  return playPromise;
+  this._play(false);
 };
 
 module.exports = Sound;

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "vinyl-source-stream": "2.0.0"
   },
   "dependencies": {
-    "@twilio/audioplayer": "1.0.4",
+    "@twilio/audioplayer": "1.0.5",
     "@twilio/voice-errors": "1.0.1",
     "backoff": "2.5.0",
     "rtcpeerconnection-shim": "1.2.8",

--- a/tests/sound.js
+++ b/tests/sound.js
@@ -1,286 +1,524 @@
 const assert = require('assert');
-const EventTarget = require('./eventtarget');
-const { inherits } = require('util');
 const sinon = require('sinon');
 
 const Sound = require('../lib/twilio/sound');
 
 describe('Sound', () => {
+  const root = global;
+  const wait = (timeout) => new Promise(r => setTimeout(r, timeout || 0));
+
+  let audioContext;
   let AudioFactory;
+  let name;
   let sound;
+  let tempAudio;
+  let url;
 
   beforeEach(() => {
-    MockAudio.clearInstances();
-    MockLegacyAudio.clearInstances();
+    audioContext = {
+      createBufferSource: () => ({
+        addEventListener: () => {},
+        connect: () => {},
+        disconnect: () => {},
+        start: () => {},
+        stop: () => {}
+      }),
+      createGain: () => ({
+        connect: () => {},
+        gain: {}
+      }),
+      decodeAudioData: () => {}
+    };
+
+    AudioFactory = function AudioFactory(url) {
+      this.url = url;
+    };
+    AudioFactory.prototype.pause = sinon.stub();
+    AudioFactory.prototype.load = sinon.stub();
+    AudioFactory.prototype.play = () => ({
+      then: () => ({ catch: () => {} })
+    });
+    AudioFactory.prototype.stop = () => {};
+    AudioFactory.prototype.addEventListener = () => {};
+
+    name = 'foo';
+    url = 'bar.com';
+    tempAudio = root.Audio;
+    root.Audio = AudioFactory;
+    sound = new Sound(name, url);
   });
 
-  context('when setSinkId is not supported', () => {
+  afterEach(() => {
+    root.Audio = tempAudio;
+  });
+
+  context('constructor', () => {
+    it('should use audioContext when passed in', () => {
+      sound = new Sound(name, url, { audioContext });
+      assert.notEqual(sound._Audio, AudioFactory);
+    });
+
+    it('should use HTML Audio when audioContext is not passed in', () => {
+      assert.equal(sound._Audio, AudioFactory);
+    });
+
+    it('should set _isSinkSupported to true', () => {
+      AudioFactory.prototype.setSinkId = function(){};
+      sound = new Sound(name, url);
+      assert(sound._isSinkSupported);
+    });
+
+    it('should set _isSinkSupported to false', () => {
+      assert(!sound._isSinkSupported);
+    });
+
+    it('should set maxDuration', () => {
+      sound = new Sound(name, url, { maxDuration: 1000 });
+      assert.equal(sound._maxDuration, 1000);
+    });
+
+    it('should set shouldLoop', () => {
+      sound = new Sound(name, url, { shouldLoop: true });
+      assert.equal(sound._shouldLoop, true);
+
+      sound = new Sound(name, url, { shouldLoop: false });
+      assert.equal(sound._shouldLoop, false);
+    });
+
+    it('should set default sinkId', () => {
+      assert.deepEqual(sound._sinkIds, ['default']);
+    });
+
+    it('should set isPlaying', () => {
+      sound._playPromise = Promise.resolve();
+      assert(sound.isPlaying);
+
+      sound._playPromise = null;
+      assert(!sound.isPlaying);
+    });
+
+    it('should play on init', () => {
+      assert(sound.isPlaying);
+    });
+  });
+
+  context('Sound.prototype._playAudioElement', () => {
+    const METHOD = Sound.prototype._playAudioElement;
+    const SINK_ID = 'foo';
+
+    let audioElement;
+    let context;
+    let toTest;
+
     beforeEach(() => {
-      AudioFactory = MockLegacyAudio;
-      sound = new Sound('foo', 'foo.bar.com', { AudioFactory: MockLegacyAudio });
-      AudioFactory.clearInstances();
+      context = {
+        _activeEls: new Map()
+      };
+
+      audioElement = new AudioFactory();
+      context._activeEls.set(SINK_ID, audioElement);
+
+      toTest = METHOD.bind(context);
     });
 
-    it('should create a muted autoplay Audio element on creation', () => {
-      sound = new Sound('foo', 'foo.bar.com', { AudioFactory: MockLegacyAudio });
-      sinon.assert.calledOnce(AudioFactory);
-      const [audio] = AudioFactory.instances;
-
-      assert.equal(audio.muted, true);
-      assert.equal(audio.preload, 'auto');
-      assert.deepEqual(audio.src, 'foo.bar.com');
-      sinon.assert.calledOnce(audio.play);
+    it('should throw error if sinkId was not initialized with an audio', () => {
+      const spy = sinon.spy(toTest);
+      try {
+        spy();
+      } catch { }
+      assert(spy.threw());
     });
 
-    describe('setSinkIds', () => {
-      it('should do nothing', () => {
-        sound.setSinkIds(['foo', 'bar']);
-        assert.deepEqual(sound._sinkIds, ['default']);
-      });
+    it('should set muted', () => {
+      toTest(SINK_ID, true);
+      assert(audioElement.muted === true);
+      toTest(SINK_ID, false);
+      assert(audioElement.muted === false);
     });
 
-    describe('play', () => {
-      it('should create a single Audio element for the default sinkId', () => {
-        sound.play();
-        sinon.assert.calledOnce(AudioFactory);
-      });
+    it('should set loop', () => {
+      toTest(SINK_ID, true, true);
+      assert(audioElement.loop === true);
+      toTest(SINK_ID, true, false);
+      assert(audioElement.loop === false);
+    });
 
-      it('should set .isPlaying to true', () => {
-        sound.play();
-        assert(sound.isPlaying);
-      });
-      
-      context('when called twice synchronously', () => {
-        beforeEach(() => {
-          sound.play();
-        });
-
-        it('should only play the last Audio element', () => {
-          return sound.play().then(() => {
-            sinon.assert.calledTwice(AudioFactory);
-            sinon.assert.notCalled(AudioFactory.instances[0].play);
-            sinon.assert.notCalled(AudioFactory.instances[0].pause);
-            sinon.assert.calledOnce(AudioFactory.instances[1].play);
-          });
-        });
-      });
-      
-      context('when called twice in order', () => {
-        beforeEach(() => {
-          return sound.play();
-        });
-
-        it('should pause the first Audio element', () => {
-          return sound.play().then(() => {
-            sinon.assert.calledTwice(AudioFactory);
-            sinon.assert.calledOnce(AudioFactory.instances[0].play);
-            sinon.assert.calledOnce(AudioFactory.instances[0].pause);
-            sinon.assert.calledOnce(AudioFactory.instances[1].play);
-            sinon.assert.notCalled(AudioFactory.instances[1].pause);
-          });
-        });
+    it('should return audio element on play success', (done) => {
+      AudioFactory.prototype.play = () => Promise.resolve();
+      audioElement.src = 'bar';
+      audioElement.srcObject = 'baz';
+      toTest(SINK_ID).then(result => {
+        assert.equal(result, audioElement);
+        assert.equal(audioElement.src, 'bar');
+        assert.equal(audioElement.srcObject, 'baz');
+        sinon.assert.notCalled(audioElement.pause);
+        sinon.assert.notCalled(audioElement.load);
+        assert.equal(context._activeEls.get(SINK_ID), audioElement);
+        done();
       });
     });
 
-    describe('stop', () => {
-      it('should not error when called before play', () => {
-        sound.stop();
-      });
-
-      it('should call .pause on the active element', () => {
-        return sound.play().then(() => {
-          sound.stop();
-          sinon.assert.calledOnce(AudioFactory.instances[0].play);
-          sinon.assert.calledOnce(AudioFactory.instances[0].pause);
-        });
+    it('should cleanup on error', (done) => {
+      AudioFactory.prototype.play = () => Promise.reject('foo');
+      audioElement.src = 'bar';
+      audioElement.srcObject = 'baz';
+      toTest(SINK_ID).catch(reason => {
+        assert.equal(reason, 'foo');
+        assert.equal(audioElement.src, '');
+        assert.equal(audioElement.srcObject, null);
+        sinon.assert.calledOnce(audioElement.pause);
+        sinon.assert.calledOnce(audioElement.load);
+        assert.equal(context._activeEls.get(SINK_ID), undefined);
+        done();
       });
     });
   });
 
-  context('when setSinkId is supported', () => {
+  context('Sound.prototype.setSinkIds', () => {
+    const METHOD = Sound.prototype.setSinkIds;
+
+    let context;
+    let toTest;
+
     beforeEach(() => {
-      AudioFactory = MockAudio;
-      sound = new Sound('foo', 'foo.bar.com', { AudioFactory: MockAudio });
-      AudioFactory.clearInstances();
+      context = {};
+      toTest = METHOD.bind(context);
     });
 
-    it('should create a muted autoplay Audio element on creation', () => {
-      sound = new Sound('foo', 'foo.bar.com', { AudioFactory: MockAudio });
-      sinon.assert.calledOnce(AudioFactory);
-      const [audio] = AudioFactory.instances;
+    it('should do nothing if sink is not supported', () => {
+      context._isSinkSupported = false;
+      context._sinkIds = ['foo'];
 
-      assert.equal(audio.muted, true);
-      assert.equal(audio.preload, 'auto');
-      assert.deepEqual(audio.src, 'foo.bar.com');
-      sinon.assert.calledOnce(audio.play);
+      toTest(['bar']);
+      assert.deepEqual(context._sinkIds, ['foo']);
     });
 
-    describe('setSinkIds', () => {
-      it('should replace the _sinkIds elements in place', () => {
-        const inputArray = ['foo', 'bar'];
-        sound.setSinkIds(inputArray);
-        assert.deepEqual(sound._sinkIds, ['foo', 'bar']);
-        assert.notEqual(sound._sinkIds, inputArray);
-      });
+    it('should set sinkIds', () => {
+      context._isSinkSupported = true;
+      context._sinkIds = ['foo'];
 
-      it('should accept a single ID', () => {
-        sound.setSinkIds('foo');
-        assert.deepEqual(sound._sinkIds, ['foo']);
+      toTest(['bar']);
+      assert.deepEqual(context._sinkIds, ['bar']);
+
+      toTest(['a', 'b']);
+      assert.deepEqual(context._sinkIds, ['a', 'b']);
+
+      toTest(['bar']);
+      assert.deepEqual(context._sinkIds, ['bar']);
+    });
+  });
+
+  context('Sound.prototype.stop', () => {
+    const METHOD = Sound.prototype.stop;
+
+    let context;
+    let toTest;
+    let activeEls;
+
+    beforeEach(() => {
+      activeEls = new Map();
+      context = {
+        _activeEls: activeEls,
+        _sinkIds: []
+      };
+      toTest = METHOD.bind(context);
+    });
+
+    it('should stop play max duration timeout', () => {
+      const stub = sinon.stub();
+      context._playPromise = {};
+      context._maxDurationTimeout = setTimeout(stub, 10);
+
+      toTest();
+      return wait(20).then(() => {
+        sinon.assert.notCalled(stub);
+        assert.equal(context._playPromise, null);
+        assert.equal(context._maxDurationTimeout, null);
       });
     });
 
-    describe('play', () => {
-      it('should create a single Audio element for the default sinkId', () => {
-        sound.play();
-        sinon.assert.calledOnce(AudioFactory);
+    it('should stop audioElements associated to a sinkId', () => {
+      const audio = new AudioFactory();
+      audio.src = 'foo';
+      audio.srcObject = 'bar';
+      activeEls.set('sink1', audio);
+      context._sinkIds = ['sink1'];
+
+      toTest();
+      assert.equal(activeEls.get('sink1'), audio);
+      assert.equal(audio.src, 'foo');
+      assert.equal(audio.srcObject, 'bar');
+      sinon.assert.calledOnce(audio.pause);
+      assert.equal(audio.currentTime, 0);
+    });
+
+    it('should destroy audioElements not associated to a sinkId', () => {
+      const audio = new AudioFactory();
+      audio.src = 'foo';
+      audio.srcObject = 'bar';
+      activeEls.set('sink1', audio);
+
+      toTest();
+      assert.equal(activeEls.get('sink1'), undefined);
+      assert.equal(audio.src, '');
+      assert.equal(audio.srcObject, null);
+      sinon.assert.called(audio.pause);
+      sinon.assert.called(audio.load);
+    });
+  });
+
+  context('Sound.prototype.play', () => {
+    const METHOD = Sound.prototype.play;
+
+    let context;
+    let toTest;
+
+    beforeEach(() => {
+      context = {
+        _play: sinon.stub()
+      };
+      toTest = METHOD.bind(context);
+    });
+
+    it('should play unmuted', () => {
+      toTest();
+      sinon.assert.calledOnce(context._play);
+      sinon.assert.calledWithExactly(context._play, false);
+
+      toTest(true);
+      sinon.assert.calledWithExactly(context._play, false);
+    });
+
+    it('should not override shouldLoop', () => {
+      toTest(true, true);
+      sinon.assert.calledOnce(context._play);
+      sinon.assert.calledWithExactly(context._play, false);
+    });
+  });
+
+  context('Sound.prototype._play', () => {
+    const METHOD = Sound.prototype._play;
+    const SINK_ID = 'foo';
+
+    let scope;
+    let toTest;
+    let activeEls;
+    let audio;
+
+    beforeEach(() => {
+      activeEls = new Map();
+      scope = {
+        _Audio: AudioFactory,
+        _activeEls: activeEls,
+        _sinkIds: [],
+        _playAudioElement: sinon.stub(),
+        stop: sinon.stub()
+      };
+
+      audio = new AudioFactory();
+      scope._sinkIds = [SINK_ID];
+      activeEls.set(SINK_ID, audio);
+
+      toTest = METHOD.bind(scope);
+    });
+
+    it('should call stop appropriately', () => {
+      scope.isPlaying = true;
+      toTest();
+      sinon.assert.calledOnce(scope.stop);
+      sinon.assert.calledOnce(scope._playAudioElement);
+      sinon.assert.callOrder(scope.stop, scope._playAudioElement);
+    });
+
+    it('should call stop after maxDuration threshold', () => {
+      scope.isPlaying = false;
+      scope._maxDuration = 10;
+      toTest();
+      return wait(20).then(() => {
+        sinon.assert.calledOnce(scope.stop);
+      });
+    });
+
+    it('should play audio if exists for a sinkId', () => {
+      toTest();
+      sinon.assert.calledOnce(scope._playAudioElement);
+    });
+
+    it('should play audio with muted and loop parameters', () => {
+      toTest(true, false);
+      sinon.assert.calledOnce(scope._playAudioElement);
+      sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, false);
+
+      toTest(true, true);
+      sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, true);
+
+      toTest(false, true);
+      sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, false, true);
+
+      toTest(false, false);
+      sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, false, false);
+    });
+
+    it('should override loop parameter properly', () => {
+      scope._shouldLoop = true;
+      toTest(true);
+      sinon.assert.calledOnce(scope._playAudioElement);
+      sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, true);
+
+      toTest(true, false);
+      sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, false);
+
+      scope._shouldLoop = false;
+      toTest(true);
+      sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, false);
+
+      toTest(true, true);
+      sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, true);
+    });
+
+    context('media cache', () => {
+      beforeEach(() => {
+        AudioFactory.prototype.addEventListener = (name, handler) => handler();
+        AudioFactory.prototype.setSinkId = function (sinkId) {
+          this.sinkId = sinkId;
+          return Promise.resolve();
+        };
+        activeEls.clear();
       });
 
-      it('should set .isPlaying to true', () => {
-        sound.play();
-        assert(sound.isPlaying);
-      });
+      it('should create and play new audio element if not cached', () => {
+        scope._isSinkSupported = false;
+        scope.url = 'foo';
 
-      it('should create a single Audio element for each sinkId', () => {
-        sound.setSinkIds(['foo', 'bar', 'baz']);
-        return sound.play().then(() => {
-          sinon.assert.calledThrice(AudioFactory);
-          assert.equal(AudioFactory.instances[0].sinkId, 'foo');
-          assert.equal(AudioFactory.instances[1].sinkId, 'bar');
-          assert.equal(AudioFactory.instances[2].sinkId, 'baz');
+        assert.equal(activeEls.size, 0);
+        toTest();
+
+        return wait(10).then(() => {
+          const audio = activeEls.get(SINK_ID);
+
+          assert.equal(audio.url, 'foo');
+          assert.equal(activeEls.size, 1);
+          sinon.assert.calledOnce(scope._playAudioElement);
         });
       });
-      
-      context('when called twice synchronously', () => {
-        beforeEach(() => {
-          sound.setSinkIds(['foo', 'bar', 'baz']);
-          sound.play();
-        });
 
-        it('should only play the last Audio elements', () => {
-          sinon.assert.calledThrice(AudioFactory);
-          return sound.play().then(() => {
-            sinon.assert.callCount(AudioFactory, 6);
-            sinon.assert.notCalled(AudioFactory.instances[0].play);
-            sinon.assert.notCalled(AudioFactory.instances[0].pause);
-            sinon.assert.notCalled(AudioFactory.instances[1].play);
-            sinon.assert.notCalled(AudioFactory.instances[1].pause);
-            sinon.assert.notCalled(AudioFactory.instances[2].play);
-            sinon.assert.notCalled(AudioFactory.instances[2].pause);
-            sinon.assert.calledOnce(AudioFactory.instances[3].play);
-            sinon.assert.calledOnce(AudioFactory.instances[4].play);
-            sinon.assert.calledOnce(AudioFactory.instances[5].play);
+      it('should set sinkId', () => {
+        scope._isSinkSupported = true;
+        toTest();
+
+        return wait(10).then(() => {
+          const audio = activeEls.get(SINK_ID);
+
+          assert.equal(audio.sinkId, SINK_ID);
+          sinon.assert.calledOnce(scope._playAudioElement);
+        });
+      });
+
+      it('should not set sinkId', () => {
+        scope._isSinkSupported = false;
+        toTest();
+
+        return wait(10).then(() => {
+          const audio = activeEls.get(SINK_ID);
+
+          assert.notEqual(audio.sinkId, SINK_ID);
+          sinon.assert.calledOnce(scope._playAudioElement);
+        });
+      });
+
+      it('should play audio with muted and loop parameters', () => {
+        toTest(true, false);
+        return wait(5).then(() => {
+          sinon.assert.calledOnce(scope._playAudioElement);
+          sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, false);
+
+          toTest(true, true);
+          return wait(5).then(() => {
+            sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, true);
+
+            toTest(false, true);
+            return wait(5).then(() => {
+              sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, false, true);
+
+              toTest(false, false);
+              return wait(5).then(() => {
+                sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, false, false);
+              });
+            });
           });
         });
       });
-      
-      context('when called twice in order', () => {
-        beforeEach(() => {
-          sound.setSinkIds(['foo', 'bar', 'baz']);
-          return sound.play();
-        });
 
-        it('should pause all Audio elements except the last', () => {
-          sinon.assert.calledThrice(AudioFactory);
-          return sound.play().then(() => {
-            sinon.assert.callCount(AudioFactory, 6);
-            sinon.assert.calledOnce(AudioFactory.instances[0].play);
-            sinon.assert.calledOnce(AudioFactory.instances[0].pause);
-            sinon.assert.calledOnce(AudioFactory.instances[1].play);
-            sinon.assert.calledOnce(AudioFactory.instances[1].pause);
-            sinon.assert.calledOnce(AudioFactory.instances[2].play);
-            sinon.assert.calledOnce(AudioFactory.instances[2].pause);
-            sinon.assert.calledOnce(AudioFactory.instances[3].play);
-            sinon.assert.notCalled(AudioFactory.instances[3].pause);
-            sinon.assert.calledOnce(AudioFactory.instances[4].play);
-            sinon.assert.notCalled(AudioFactory.instances[4].pause);
-            sinon.assert.calledOnce(AudioFactory.instances[5].play);
-            sinon.assert.notCalled(AudioFactory.instances[5].pause);
+      it('should override loop parameter properly', () => {
+        scope._shouldLoop = true;
+        toTest(true);
+        return wait(5).then(() => {
+          sinon.assert.calledOnce(scope._playAudioElement);
+          sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, true);
+
+          toTest(true, false);
+          return wait(5).then(() => {
+            sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, false);
+
+            scope._shouldLoop = false;
+            toTest(true);
+            return wait(5).then(() => {
+              sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, false);      
+              toTest(true, true);
+
+              return wait(5).then(() => {
+                sinon.assert.calledWithExactly(scope._playAudioElement, SINK_ID, true, true);
+              });
+            });
           });
         });
       });
-    });
 
-    describe('stop', () => {
-      it('should not error when called before play', () => {
-        sound.stop();
+      it('should not play if stop is called while waiting for canplaythrough event', () => {
+        AudioFactory.prototype.addEventListener = (name, handler) => {
+          setTimeout(() => {
+            scope._playPromise = null;
+            handler();
+          }, 5);
+        };
+        scope.url = 'foo';
+
+        assert.equal(activeEls.size, 0);
+        toTest();
+
+        return wait(10).then(() => {
+          const audio = activeEls.get(SINK_ID);
+
+          assert.equal(audio.url, 'foo');
+          assert.equal(activeEls.size, 1);
+          sinon.assert.notCalled(scope._playAudioElement);
+        });
+
       });
 
-      it('should call .pause on all active elements', () => {
-        sound.setSinkIds(['foo', 'bar']);
-        return sound.play().then(() => {
-          sound.stop();
-          sinon.assert.calledOnce(AudioFactory.instances[0].play);
-          sinon.assert.calledOnce(AudioFactory.instances[0].pause);
-          sinon.assert.calledOnce(AudioFactory.instances[1].play);
-          sinon.assert.calledOnce(AudioFactory.instances[1].pause);
+      it('should not play if stop is called while waiting for setSinkId', () => {
+        scope._isSinkSupported = true;
+        AudioFactory.prototype.setSinkId = function (sinkId) {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              scope._playPromise = null;
+              resolve();
+            }, 5);
+          });
+        };
+        scope.url = 'foo';
+
+        assert.equal(activeEls.size, 0);
+        toTest();
+
+        return wait(10).then(() => {
+          const audio = activeEls.get(SINK_ID);
+
+          assert.equal(audio.url, 'foo');
+          assert.equal(activeEls.size, 1);
+          sinon.assert.notCalled(scope._playAudioElement);
         });
       });
     });
   });
 });
-
-/**
- * MockAudio - Has setSinkId
- */
-function MockAudio(src) {
-  EventTarget.call(this);
-
-  this.src = src;
-  this.pause = sinon.spy(this.pause);
-  this.play = sinon.spy(this.play);
-  this.setSinkId = sinon.spy(this.setSinkId);
-  MockAudio.instances.push(this);
-}
-
-inherits(MockAudio, EventTarget);
-
-MockAudio.instances = [];
-MockAudio.clearInstances = function() {
-  this.instances.splice(0, this.instances.length);
-  this.reset();
-}
-
-MockAudio.prototype.addEventListener = (eventName, handler) => {
-  if (eventName === 'canplaythrough') {
-    setTimeout(handler);
-  }
-}
-MockAudio.prototype.load = () => { }
-MockAudio.prototype.pause = () => { }
-MockAudio.prototype.play = () => { }
-MockAudio.prototype.setSinkId = function(sinkId) {
-  this.sinkId = sinkId;
-  return Promise.resolve();
-}
-
-MockAudio = sinon.spy(MockAudio);
-
-/**
- * MockLegacyAudio - No setSinkId
- */
-function MockLegacyAudio(src) {
-  EventTarget.call(this);
-
-  this.src = src;
-  this.pause = sinon.spy(this.pause);
-  this.play = sinon.spy(this.play);
-  MockLegacyAudio.instances.push(this);
-}
-
-inherits(MockLegacyAudio, EventTarget);
-
-MockLegacyAudio.instances = [];
-MockLegacyAudio.clearInstances = function() {
-  this.instances.splice(0, this.instances.length);
-  this.reset();
-}
-
-MockLegacyAudio.prototype.addEventListener = (eventName, handler) => {
-  if (eventName === 'canplaythrough') {
-    setTimeout(handler);
-  }
-}
-MockLegacyAudio.prototype.load = () => { }
-MockLegacyAudio.prototype.pause = () => { }
-MockLegacyAudio.prototype.play = () => { }
-MockLegacyAudio = sinon.spy(MockLegacyAudio);


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6632](https://issues.corp.twilio.com/browse/CLIENT-6632)

### Description

Currently, ringtone media files are always downloaded whenever we play them. Audio elements are always being created as well. This PR caches the Audio elements to prevent re-downloading of media files. Cache is invalidated if we change sinkIds.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
