### PR TITLE
CLIENT-6664 | Fix rtt and mos calculation for browsers not supporting…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.9.2 (In Progress)
+===================
+
+Bug Fixes
+---------
+
+* Fixed an issue on Safari where `sample.mos`, emitted from `Connection.on('sample', handler(sample))`, is always null. (CLIENT-6664)
+
 1.9.1 (Sept 13, 2019)
 ===================
 

--- a/lib/twilio/rtc/stats.js
+++ b/lib/twilio/rtc/stats.js
@@ -108,9 +108,7 @@ function createRTCSample(statsReport) {
 
         break;
       case 'transport':
-        if (stats.dtlsState === 'connected') {
-          activeTransportId = stats.id;
-        }
+        activeTransportId = stats.id;
         break;
     }
   });

--- a/tests/payloads/rtcstatsreport.json
+++ b/tests/payloads/rtcstatsreport.json
@@ -264,7 +264,6 @@
     "type": "transport",
     "bytesSent": 10931341,
     "bytesReceived": 10858033,
-    "dtlsState": "connected",
     "selectedCandidatePairId": "RTCIceCandidatePair_BMuAX3Yg_yB1+bJsu",
     "localCertificateId": "RTCCertificate_AF:45:A0:00:47:1B:0A:13:1A:24:1F:29:5B:0A:58:30:E7:FB:82:80:05:30:BA:B1:06:C4:82:F3:AF:E5:34:E8",
     "remoteCertificateId": "RTCCertificate_30:74:CA:5E:6B:4C:DD:D0:63:4A:03:23:F3:F5:A7:3F:82:E9:13:06"

--- a/tests/stats.js
+++ b/tests/stats.js
@@ -38,6 +38,37 @@ describe('getStats', () => {
     });
   });
 
+  context('In browsers not supporting dtlsState', () => {
+    let stats;
+
+    before(() => {
+      const statsReport = MockRTCStatsReport.fromArray(standardPayload);
+      const peerConnection = {
+        getStats() { return Promise.resolve(statsReport); }
+      };
+
+      return getStats(peerConnection).then(_stats => {
+        stats = _stats;
+      });
+    });
+
+    it('should correctly transform a standard RTCStatsReport', () => {
+      assert.deepEqual(stats, {
+        codecName: 'PCMU',
+        timestamp: 1492027598825.6,
+        rtt: 86,
+        jitter: 3,
+        packetsLost: 41,
+        packetsReceived: 61687,
+        bytesReceived: 10610164,
+        packetsSent: 61939,
+        bytesSent: 10653508,
+        localAddress: '107.20.226.156',
+        remoteAddress: '54.172.60.184'
+      });
+    });
+  });
+
   context('In Edge', () => {
     let stats;
 


### PR DESCRIPTION
… dtlsState

<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6664](https://issues.corp.twilio.com/browse/CLIENT-6664)

### Description

Some browsers such as Safari doesn't support dtls state in rtc stats. If this doesn't exists, we currently skip rtt calculation which cuases mos to return null. This PR fixes that.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm run build:release`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
