### PR TITLE
Copying workingdir instead of mounting to fix permission issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-Dockerfile
-node_modules
-package-lock.json
-dist
-es5
-docs
-tests/docker/proxy/node_modules
-tests/docker/proxy/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,6 @@ RUN echo "Installing Firefox: $BVER" \
 
 ENV FIREFOX_BIN=/application/firefox/firefox
 
+COPY . /app
+
 CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,4 @@ services:
     working_dir: /app
     container_name: twilio-client-integration-test
     volumes:
-      - "./:/app"
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Recently, we had an issue where artifacts cannot be deleted which breaks release process. This happens because docker is taking over the files that are mounted. This PR will not mount the files, but copy instead.