### PR TITLE
CLIENT-6786 | Retrieve CORS headers when using media element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.9.3 (In Progress)
+===================
+
+Bug Fixes
+---------
+
+* Fixed an issue where audio files sometimes shows CORS errors on the console. (CLIENT-6786)
+
 1.9.2 (Oct 3, 2019)
 ===================
 

--- a/lib/twilio/sound.js
+++ b/lib/twilio/sound.js
@@ -145,6 +145,16 @@ Sound.prototype._play = function _play(forceIsMuted, forceShouldLoop) {
 
     audioElement = new self._Audio(self.url);
 
+    // Make sure the browser always retrieves the resource using CORS.
+    // By default when using media tags, origin header is not sent to server
+    // which causes the server to not return CORS headers. When this caches
+    // on the CDN or browser, it causes issues to future requests that needs CORS,
+    // which is true when using AudioContext. Please note that we won't have to do this
+    // once we migrate to CloudFront.
+    if (typeof audioElement.setAttribute === 'function') {
+      audioElement.setAttribute('crossorigin', 'anonymous');
+    }
+
     /**
      * (rrowland) Bug in Chrome 53 & 54 prevents us from calling Audio.setSinkId without
      *   crashing the tab. https://bugs.chromium.org/p/chromium/issues/detail?id=655342

--- a/tests/sound.js
+++ b/tests/sound.js
@@ -344,6 +344,13 @@ describe('Sound', () => {
       sinon.assert.calledOnce(scope._playAudioElement);
     });
 
+    it('should set crossorigin attribute when using html5 audio', () => {
+      AudioFactory.prototype.setAttribute = sinon.stub();
+      activeEls.clear();
+      toTest();
+      sinon.assert.calledWithExactly(audio.setAttribute, 'crossorigin', 'anonymous');
+    });
+
     it('should play audio with muted and loop parameters', () => {
       toTest(true, false);
       sinon.assert.calledOnce(scope._playAudioElement);


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6786](https://issues.corp.twilio.com/browse/CLIENT-6786)

### Description

Make sure the browser always retrieves the resource using CORS.
By default when using media tags, origin header is not sent to server
which causes the server to not return CORS headers. When this caches
on the CDN or browser, it causes issues to future requests that needs CORS,
which is true when using AudioContext. Please note that we won't have to do this
once we migrated to CloudFront.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
