### PR TITLE
CLIENT-6832 | Update querystring to clear cache for audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.9.4 (In Progress)
+===================
+
+Bug Fixes
+---------
+
+* Update querystring to clear cached audio files without CORS headers. (CLIENT-6832)
+
 1.9.3 (Oct 15, 2019)
 ===================
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -670,7 +670,9 @@ class Device extends EventEmitter {
     for (const name of Object.keys(defaultSounds)) {
       const soundDef: ISoundDefinition = defaultSounds[name];
 
-      const defaultUrl: string = `${C.SOUNDS_BASE_URL}/${soundDef.filename}.${Device.extension}?cache=1_4_23`;
+      const defaultUrl: string = `${C.SOUNDS_BASE_URL}/${soundDef.filename}.${Device.extension}`
+        + `?cache=${C.RELEASE_VERSION}`;
+
       const soundUrl: string = this.options.sounds && this.options.sounds[name as Device.SoundName] || defaultUrl;
       const sound: any = new this.options.soundFactory(name, soundUrl, {
         audioContext: this.options.disableAudioContextSounds ? null : Device.audioContext,


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6832](https://issues.corp.twilio.com/browse/CLIENT-6832)

### Description

After adding crossorigin attribute in CLIENT-6786, we need to make sure we bust the browser cache to make sure CORS headers are downloaded if the customer decides to use AudioContext.

This PR is updating cache buster.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
