### PR TITLE
[CLIENT-6831] Remove region checking logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+1.9.5 (In Progress)
+===================
+
+Improvements
+---------
+
+* In order to support new regions without requiring SDK updates in the future, the SDK no longer locally verifies the region option passed to `Device.setup` options. As a result, if an invalid region is passed, a connection error will be emitted after the connection is attempted. We recommend always testing to make sure your specified region (if any) works before pushing any change to production. For a list of supported regions refer to "https://www.twilio.com/docs/voice/client/regions". (CLIENT-6831)
+
+
 1.9.4 (Oct 28, 2019)
 ===================
 
@@ -299,8 +308,8 @@ Browser Support
 * We are now using RTCP values for RTT where available. Initially, this will not affect Chrome
   because Chrome has [not yet implemented support](https://bugs.chromium.org/p/webrtc/issues/detail?id=9545).
   Additionally, having access to RTT will allow FireFox to calculate and report MOS, however FireFox is
-  currently affected by [a regression](https://bugzilla.mozilla.org/show_bug.cgi?id=1525341) causing 
-  jitter to be reported as 0, which will make MOS scores appear slightly better than they actually 
+  currently affected by [a regression](https://bugzilla.mozilla.org/show_bug.cgi?id=1525341) causing
+  jitter to be reported as 0, which will make MOS scores appear slightly better than they actually
   are until it's fixed.
 
 1.6.7 (Feb 12, 2019)

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -7,7 +7,6 @@ import { EventEmitter } from 'events';
 import Device from './device';
 import DialtonePlayer from './dialtonePlayer';
 import { GeneralErrors, InvalidArgumentError, MediaErrors, TwilioError } from './errors';
-import { Region } from './regions';
 import RTCSample from './rtc/sample';
 import RTCWarning from './rtc/warning';
 import StatsMonitor from './statsMonitor';
@@ -1616,7 +1615,7 @@ namespace Connection {
     /**
      * The Region currently connected to.
      */
-    region?: Region;
+    region?: string;
 
     /**
      * An RTCConfiguration to pass to the RTCPeerConnection constructor.

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -17,7 +17,11 @@ import {
   SignalingErrors,
 } from './errors';
 import { PStream } from './pstream';
-import { getRegionShortcode, getRegionURI, Region } from './regions';
+import {
+  defaultRegion,
+  getRegionShortcode,
+  getRegionURI,
+} from './regions';
 import Log, { LogLevel } from './tslog';
 import { Exception, queryToJson } from './util';
 
@@ -300,7 +304,7 @@ class Device extends EventEmitter {
   /**
    * The region the {@link Device} is connected to.
    */
-  private _region: Region | string | null = null;
+  private _region: string | null = null;
 
   /**
    * The current status of the {@link Device}.
@@ -328,7 +332,7 @@ class Device extends EventEmitter {
     iceServers: [],
     noRegister: false,
     pStreamFactory: PStream,
-    region: Region.Gll,
+    region: defaultRegion,
     rtcConstraints: { },
     soundFactory: Sound,
     sounds: { },
@@ -643,9 +647,9 @@ class Device extends EventEmitter {
       this.sounds[eventName] = getOrSetSound.bind(null, eventName);
     });
 
-    const regionURI = getRegionURI(this.options.region, (newRegion: string) => {
-      this._log.warn(`Region ${this.options.region} is deprecated, please use ${newRegion}.`);
-    });
+    const regionURI = getRegionURI(this.options.region, newRegion => this._log.warn(
+      `Region ${this.options.region} is deprecated, please use ${newRegion}.`,
+    ));
 
     this.options.chunderw = `wss://${this.options.chunderw || regionURI}/signal`;
 
@@ -1473,7 +1477,7 @@ namespace Device {
     /**
      * The region code of the region to connect to.
      */
-    region?: Region;
+    region?: string;
 
     /**
      * An RTCConfiguration to pass to the RTCPeerConnection constructor.

--- a/lib/twilio/wstransport.ts
+++ b/lib/twilio/wstransport.ts
@@ -289,7 +289,19 @@ export default class WSTransport extends EventEmitter {
   /**
    * Called in response to WebSocket#close event.
    */
-  private _onSocketClose = (): void => {
+  private _onSocketClose = (event: CloseEvent): void => {
+    this._log.info(`Received websocket close event code: ${event.code}`);
+    if (event.code === 1006) {
+      this.emit('error', {
+        code: 31005,
+        message: event.reason ||
+          'Websocket connection to Twilio\'s signaling servers were ' +
+          'unexpectedly ended. If this is happening consistently, there may ' +
+          'be an issue resolving the hostname provided. If a region is being ' +
+          'specified in Device setup, ensure it\'s a valid region.',
+        twilioError: new SignalingErrors.ConnectionError(),
+      });
+    }
     this._closeSocket();
   }
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -81,3 +81,4 @@ require('./unit/tslog');
 require('./unit/wstransport');
 require('./unit/statsMonitor');
 require('./unit/error');
+require('./unit/regions');

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -1,10 +1,10 @@
 import Connection from '../../lib/twilio/connection';
 import Device from '../../lib/twilio/device';
-import { DeprecatedRegion, Region, regionShortcodes } from '../../lib/twilio/regions';
+import { regionShortcodes } from '../../lib/twilio/regions';
 import { GeneralErrors } from '../../lib/twilio/errors';
 
 import * as assert from 'assert';
-import { EventEmitter } from 'events';    
+import { EventEmitter } from 'events';
 import { SinonFakeTimers, SinonSpy, SinonStubbedInstance } from 'sinon';
 import * as sinon from 'sinon';
 
@@ -231,7 +231,7 @@ describe('Device', function() {
       });
     });
   });
-  
+
   context('after Device is initialized', () => {
     const rtcConfiguration = { foo: 'bar', abc: 123 };
 
@@ -278,7 +278,7 @@ describe('Device', function() {
       it('should call ignore on all existing connections', () => {
         const connections: any[] = [];
         for (let i = 0; i < 10; i++) {
-          connections.push({ ignore: sinon.spy() }); 
+          connections.push({ ignore: sinon.spy() });
         }
         device['connections'] = connections;
         device.connect();
@@ -595,6 +595,15 @@ describe('Device', function() {
         pstream.register.reset();
         clock.tick(30000 + 1);
         sinon.assert.notCalled(pstream.register);
+      });
+
+      it('should emit Device.error if code is 31005', () => {
+        device.emit = sinon.spy();
+        pstream.emit('error', { error: { code: 31005 } });
+        sinon.assert.calledOnce(device.emit as any);
+        sinon.assert.calledWith(device.emit as any, 'error');
+        const errorObject = (device.emit as sinon.SinonSpy).getCall(0).args[1];
+        assert.equal(31005, errorObject.code);
       });
     });
 

--- a/tests/unit/regions.ts
+++ b/tests/unit/regions.ts
@@ -1,0 +1,38 @@
+import { getRegionURI, deprecatedRegions } from '../../lib/twilio/regions';
+import * as assert from 'assert';
+
+describe('regions', () => {
+  describe('getRegionURI', () => {
+    (Object as any).entries(deprecatedRegions).forEach(([deprecatedRegion, newRegion]: [string, string]) => {
+      it(`should note ${deprecatedRegion} as deprecated and recommend ${newRegion}`, async () => {
+        const uri = getRegionURI(deprecatedRegion);
+        const region = await new Promise(async resolveRegion => {
+          getRegionURI(deprecatedRegion, resolveRegion);
+        });
+
+        assert.equal(`chunderw-vpc-gll-${newRegion}.twilio.com`, uri);
+        assert.equal(newRegion, region);
+      });
+    });
+
+    it('should not call `onDeprecated` for a non-deprecated region', () => {
+      const region = 'some_region';
+      let called = false;
+      const uri = getRegionURI(region, () => called = true);
+
+      assert.equal(`chunderw-vpc-gll-${region}.twilio.com`, uri);
+      assert(!called);
+    });
+
+    describe('should return the default chunderw uri', () => {
+      it('when region is `undefined`', () => {
+        const region = undefined;
+        assert.equal(`chunderw-vpc-gll.twilio.com`, getRegionURI(region));
+      });
+      it('when region is `gll`', () => {
+        const region = 'gll';
+        assert.equal(`chunderw-vpc-gll.twilio.com`, getRegionURI(region));
+      });
+    });
+  });
+});

--- a/tests/unit/wstransport.ts
+++ b/tests/unit/wstransport.ts
@@ -217,14 +217,14 @@ describe('WSTransport', () => {
     context('when receiving a heartbeat', () => {
       it('should respond', () => {
         socket._readyState = WebSocket.OPEN;
-        socket.dispatchEvent({ type: 'message', data: '\n' }); 
+        socket.dispatchEvent({ type: 'message', data: '\n' });
         assert.equal(socket.send.args[0][0], '\n');
       });
 
       it('should not emit', () => {
         transport.emit = sinon.spy();
         socket._readyState = WebSocket.OPEN;
-        socket.dispatchEvent({ type: 'message', data: '\n' }); 
+        socket.dispatchEvent({ type: 'message', data: '\n' });
         assert.equal((transport as any).emit.callCount, 0);
       });
     });
@@ -232,14 +232,14 @@ describe('WSTransport', () => {
     context('when receiving a message', () => {
       it('should not respond with a heartbeat', () => {
         socket._readyState = WebSocket.OPEN;
-        socket.dispatchEvent({ type: 'message', data: 'foo' }); 
+        socket.dispatchEvent({ type: 'message', data: 'foo' });
         assert.equal((socket as any).send.callCount, 0);
       });
 
       it('should emit the message', () => {
         transport.emit = sinon.spy();
         socket._readyState = WebSocket.OPEN;
-        socket.dispatchEvent({ type: 'message', data: 'foo' }); 
+        socket.dispatchEvent({ type: 'message', data: 'foo' });
         assert.equal((transport as any).emit.callCount, 1);
         assert.equal((transport as any).emit.args[0][1].data, 'foo');
       });
@@ -323,6 +323,15 @@ describe('WSTransport', () => {
       assert.equal(ee.listenerCount('error'), 0);
       assert.equal(ee.listenerCount('message'), 0);
       assert.equal(ee.listenerCount('open'), 0);
+    });
+
+    it('should emit an error if the socket was closed abnormally (with code 1006)', async () => {
+      transport.emit = sinon.spy();
+      socket.dispatchEvent({ type: 'close', code: 1006 });
+      assert.equal((transport as any).emit.callCount, 2);
+      assert.equal((transport as any).emit.args[0][0], 'error');
+      assert.equal((transport as any).emit.args[0][1].code, 31005);
+      assert.equal((transport as any).emit.args[1][0], 'close');
     });
   });
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6831](https://issues.corp.twilio.com/browse/CLIENT-6831)

### Description

This PR removes region checking logic to allow for the use of free-strings as region shortcodes. At the moment, there is no difference in the signaling stack logic between a network loss error and an incorrect region error, meaning that if the websocket can not connect in either case, we have the same error (and consequentially the same reconnect logic).

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
