### PR TITLE
CLIENT-6869 | Adding PeerConnection.connectionState insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Improvements
 
 * In order to support new regions without requiring SDK updates in the future, the SDK no longer locally verifies the region option passed to `Device.setup` options. As a result, if an invalid region is passed, a connection error will be emitted after the connection is attempted. We recommend always testing to make sure your specified region (if any) works before pushing any change to production. For a list of supported regions refer to "https://www.twilio.com/docs/voice/client/regions". (CLIENT-6831)
 
+* We are now sending PeerConnection connection state change events to Insights as `pc-connection-state`. (CLIENT-6869)
 
 1.9.4 (Oct 28, 2019)
 ===================

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -326,10 +326,8 @@ class Connection extends EventEmitter {
       let level = 'debug';
       const dtlsTransport = this.mediaStream.getRTCDtlsTransport();
 
-      if (state === 'failed' && dtlsTransport && dtlsTransport.state === 'failed') {
-        level = 'error';
-      } else if (state === 'failed') {
-        level = 'warning';
+      if (state === 'failed') {
+        level = dtlsTransport && dtlsTransport.state === 'failed' ? 'error' : 'warning';
       }
       this._publisher.post(level, 'pc-connection-state', state, null, this);
     };

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -323,7 +323,19 @@ class Connection extends EventEmitter {
       this.emit('volume', inputVolume, outputVolume);
     };
 
-    this.mediaStream.onmediaconnectionstatechange = (state: string): void => {
+    this.mediaStream.onpcconnectionstatechange = (state: string): void => {
+      let level = 'debug';
+      const dtlsTransport = this.mediaStream.getRTCDtlsTransport();
+
+      if (state === 'failed' && dtlsTransport && dtlsTransport.state === 'failed') {
+        level = 'error';
+      } else if (state === 'failed') {
+        level = 'warning';
+      }
+      this._publisher.post(level, 'pc-connection-state', state, null, this);
+    };
+
+    this.mediaStream.oniceconnectionstatechange = (state: string): void => {
       const level = state === 'failed' ? 'error' : 'debug';
       this._publisher.post(level, 'ice-connection-state', state, null, this);
     };

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -948,11 +948,8 @@ PeerConnection.prototype.getOrCreateDTMFSender = function getOrCreateDTMFSender(
  * @returns RTCDtlTransport
  */
 PeerConnection.prototype.getRTCDtlsTransport = function getRTCDtlsTransport() {
-  if (typeof this.version.pc.getSenders === 'function') {
-    const sender = this.version.pc.getSenders()[0];
-    return sender && sender.transport || null;
-  }
-  return null;
+  const sender = typeof this.version.pc.getSenders === 'function' && this.version.pc.getSenders()[0];
+  return sender && sender.transport || null;
 };
 
 PeerConnection.prototype._canStopMediaStreamTrack = () => typeof MediaStreamTrack.prototype.stop === 'function';

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -950,7 +950,7 @@ PeerConnection.prototype.getOrCreateDTMFSender = function getOrCreateDTMFSender(
 PeerConnection.prototype.getRTCDtlsTransport = function getRTCDtlsTransport() {
   if (typeof this.version.pc.getSenders === 'function') {
     const sender = this.version.pc.getSenders()[0];
-    return sender && sender.transport ? sender.transport : null;
+    return sender && sender.transport || null;
   }
   return null;
 };

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -36,8 +36,9 @@ function PeerConnection(audioHelper, pstream, getUserMedia, options) {
   this.onfailed = noop;
   this.onreconnected = noop;
   this.onsignalingstatechange = noop;
-  this.onmediaconnectionstatechange = noop;
   this.onicegatheringstatechange = noop;
+  this.oniceconnectionstatechange = noop;
+  this.onpcconnectionstatechange = noop;
   this.onicecandidate = noop;
   this.onvolume = noop;
   this.version = null;
@@ -400,8 +401,6 @@ PeerConnection.prototype._onMediaConnectionStateChange = function(newState) {
       this.onfailed(message);
       break;
   }
-  this.log(`media connection state is "${newState}"`);
-  this.onmediaconnectionstatechange(newState);
 };
 
 PeerConnection.prototype._setSinkIds = function(sinkIds) {
@@ -650,6 +649,7 @@ PeerConnection.prototype._setupChannel = function() {
   // Chrome 72+
   pc.onconnectionstatechange = () => {
     this.log(`pc.connectionState is "${pc.connectionState}"`);
+    this.onpcconnectionstatechange(pc.connectionState);
     this._onMediaConnectionStateChange(pc.connectionState);
   };
 
@@ -663,6 +663,7 @@ PeerConnection.prototype._setupChannel = function() {
 
   pc.oniceconnectionstatechange = () => {
     this.log(`pc.iceConnectionState is "${pc.iceConnectionState}"`);
+    this.oniceconnectionstatechange(pc.iceConnectionState);
     this._onMediaConnectionStateChange(pc.iceConnectionState);
   };
 };
@@ -939,6 +940,18 @@ PeerConnection.prototype.getOrCreateDTMFSender = function getOrCreateDTMFSender(
 
   this.log('RTCPeerConnection does not support RTCDTMFSender');
   this._dtmfSenderUnsupported = true;
+  return null;
+};
+
+/**
+ * Get the RTCDtlTransport object from the PeerConnection
+ * @returns RTCDtlTransport
+ */
+PeerConnection.prototype.getRTCDtlsTransport = function getRTCDtlsTransport() {
+  if (typeof this.version.pc.getSenders === 'function') {
+    const sender = this.version.pc.getSenders()[0];
+    return sender && sender.transport ? sender.transport : null;
+  }
   return null;
 };
 

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -1080,24 +1080,45 @@ describe('PeerConnection', () => {
         onopen: sinon.stub(),
         onicecandidate: sinon.stub(),
         onicegatheringstatechange: sinon.stub(),
+        oniceconnectionstatechange: sinon.stub(),
+        onpcconnectionstatechange: sinon.stub(),
+        _onMediaConnectionStateChange: sinon.stub(),
       };
       toTest = METHOD.bind(context);
     });
 
-    it('Should call _onMediaConnectionStateChange on ice failed', () => {
-      context._onMediaConnectionStateChange = sinon.stub();
-      version.pc.iceConnectionState = 'failed';
-      toTest();
-      version.pc.oniceconnectionstatechange();
-      sinon.assert.callCount(context._onMediaConnectionStateChange, 1);
-    });
+    ['new', 'checking', 'connected', 'completed', 'failed', 'disconnected', 'closed'].forEach((currentState) => {
+      it(`Should call _onMediaConnectionStateChange when pc.iceConnectionState transitions to "${currentState}" state`, () => {
+        version.pc.iceConnectionState = currentState;
+        toTest();
+        version.pc.oniceconnectionstatechange();
+        sinon.assert.callCount(context._onMediaConnectionStateChange, 1);
+        sinon.assert.calledWith(context._onMediaConnectionStateChange, currentState);
+      });
+  
+      it(`Should call _onMediaConnectionStateChange when pc.connectionState transitions to "${currentState}" state`, () => {
+        version.pc.connectionState = currentState;
+        toTest();
+        version.pc.onconnectionstatechange();
+        sinon.assert.callCount(context._onMediaConnectionStateChange, 1);
+        sinon.assert.calledWith(context._onMediaConnectionStateChange, currentState);
+      });
 
-    it('Should call _onMediaConnectionStateChange on pc failed', () => {
-      context._onMediaConnectionStateChange = sinon.stub();
-      version.pc.connectionState = 'failed';
-      toTest();
-      version.pc.onconnectionstatechange();
-      sinon.assert.callCount(context._onMediaConnectionStateChange, 1);
+      it(`Should call mediaStream.oniceconnectionstatechange when pc.iceConnectionState transitions to "${currentState}" state`, () => {
+        version.pc.iceConnectionState = currentState;
+        toTest();
+        version.pc.oniceconnectionstatechange();
+        sinon.assert.callCount(context.oniceconnectionstatechange, 1);
+        sinon.assert.calledWith(context.oniceconnectionstatechange, currentState);
+      });
+
+      it(`Should call mediaStream.onpcconnectionstatechange when pc.connectionState transitions to "${currentState}" state`, () => {
+        version.pc.connectionState = currentState;
+        toTest();
+        version.pc.onconnectionstatechange();
+        sinon.assert.callCount(context.onpcconnectionstatechange, 1);
+        sinon.assert.calledWith(context.onpcconnectionstatechange, currentState);
+      });
     });
   });
 
@@ -1114,31 +1135,13 @@ describe('PeerConnection', () => {
         onreconnected: sinon.stub(),
         ondisconnected: sinon.stub(),
         onfailed: sinon.stub(),
-        onmediaconnectionstatechange: sinon.stub(),
       };
       toTest = METHOD.bind(context);
-    });
-
-    it('Should ignore other states', () => {
-      context._iceState = 'connected';
-      toTest('new');
-      toTest('connecting');
-      toTest('checking');
-      toTest('completed');
-      toTest('closed');
-      sinon.assert.notCalled(context.onmediaconnectionstatechange);
-    });
-
-    it('Should ignore if new state and previous states are the same', () => {
-      context._iceState = 'connected';
-      toTest('connected');
-      sinon.assert.notCalled(context.onmediaconnectionstatechange);
     });
 
     it('Should save current state internally', () => {
       context._iceState = 'connected';
       toTest('disconnected');
-      sinon.assert.calledWith(context.onmediaconnectionstatechange, 'disconnected');
       assert.equal(context._iceState, 'disconnected');
     });
 
@@ -1166,21 +1169,6 @@ describe('PeerConnection', () => {
       context._iceState = 'failed';
       toTest('connected');
       sinon.assert.calledWith(context.onreconnected, 'ICE liveliness check succeeded. Connection with Twilio restored');
-    });
-
-    it('Should call onmediaconnectionstatechange', () => {
-      context._iceState = 'new';
-      toTest('connected');
-      sinon.assert.calledWith(context.onmediaconnectionstatechange, 'connected');
-
-      toTest('disconnected');
-      sinon.assert.calledWith(context.onmediaconnectionstatechange, 'disconnected');
-
-      toTest('failed');
-      sinon.assert.calledWith(context.onmediaconnectionstatechange, 'failed');
-
-      toTest('connected');
-      sinon.assert.calledWith(context.onmediaconnectionstatechange, 'connected');
     });
   });
 

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -1644,6 +1644,48 @@ describe('PeerConnection', () => {
     });
   });
 
+  context('PeerConnection.prototype.getRTCDtlsTransport', () => {
+    const METHOD = PeerConnection.prototype.getRTCDtlsTransport;
+
+    let toTest = null;
+    let context = null;
+    let pc = null;
+
+    beforeEach(() => {
+      pc = {};
+      context = {
+        version: {
+          pc
+        }
+      };
+      toTest = METHOD.bind(context);
+    });
+
+    it('Should return null if getSenders is not supported', () => {
+      const transport = toTest();
+      assert.equal(transport, null);
+    });
+
+    it('Should return null if getSenders is supported but there is no RTPSender available', () => {
+      pc.getSenders = () => [];
+      const transport = toTest();
+      assert.equal(transport, null);
+    });
+
+    it('Should return null if there is RTPSender available but RTCDtlsTransport is not supported', () => {
+      pc.getSenders = () => [{}];
+      const transport = toTest();
+      assert.equal(transport, null);
+    });
+
+    it('Should return RTCDtlsTransport if it is available', () => {
+      const sender = { transport: { foo: 'bar' } };
+      pc.getSenders = () => [sender];
+      const transport = toTest();
+      assert.deepEqual(transport, sender.transport);
+    });
+  });
+
   context('PeerConnection.prototype.getOrCreateDTMFSender', () => {
     const METHOD = PeerConnection.prototype.getOrCreateDTMFSender;
     const DTMF_SENDER = 'dtmf sender';

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -870,14 +870,26 @@ describe('Connection', function() {
       });
     });
 
-    describe('mediaStream.onmediaconnectionstatechange', () => {
+    describe('mediaStream.onpcconnectionstatechange', () => {
+      it('should publish an warning event if state is failed', () => {
+        mediaStream.onpcconnectionstatechange('failed');
+        sinon.assert.calledWith(publisher.post, 'warning', 'pc-connection-state', 'failed');
+      });
+
+      it('should publish a debug event if state is not failed', () => {
+        mediaStream.onpcconnectionstatechange('foo');
+        sinon.assert.calledWith(publisher.post, 'debug', 'pc-connection-state', 'foo');
+      });
+    });
+
+    describe('mediaStream.oniceconnectionstatechange', () => {
       it('should publish an error event if state is failed', () => {
-        mediaStream.onmediaconnectionstatechange('failed');
+        mediaStream.oniceconnectionstatechange('failed');
         sinon.assert.calledWith(publisher.post, 'error', 'ice-connection-state', 'failed');
       });
 
       it('should publish a debug event if state is not failed', () => {
-        mediaStream.onmediaconnectionstatechange('foo');
+        mediaStream.oniceconnectionstatechange('foo');
         sinon.assert.calledWith(publisher.post, 'debug', 'ice-connection-state', 'foo');
       });
     });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6869](https://issues.corp.twilio.com/browse/CLIENT-6869)

### Description

Adding insight events when PeerConnection.connectionState changes.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
