### PR TITLE
CLIENT-6897 | Dont hangup on getUserMedia failure

### DIFF
--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -600,7 +600,9 @@ class Connection extends EventEmitter {
         }, this);
       }
 
-      this._disconnect();
+      // Reset the status back to pending
+      this._status = Connection.State.Pending;
+
       this.emit('error', { message, code });
     });
   }

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -214,6 +214,16 @@ describe('Connection', function() {
         sinon.assert.calledWith(mediaStream.openWithConstraints, { bar: 'baz' });
       });
 
+      it('should transition state to Connecting', () => {
+        mediaStream.openWithConstraints = () => Promise.resolve();
+        Object.assign(options, { audioConstraints: { bar: 'baz' } });
+        conn = new Connection(config, options);
+        conn.accept();
+        return (() => Promise.resolve())().then(() => {
+          assert.equal(conn.status(), Connection.State.Connecting);
+        });
+      });
+
       it('should result in a `denied` error when `getUserMedia` does not allow the application to access the media', () => {
         return new Promise(resolve => {
           mediaStream.openWithConstraints = () => {
@@ -246,6 +256,14 @@ describe('Connection', function() {
           const p = Promise.resolve();
           wait = p.then(() => Promise.resolve());
           return p;
+        });
+      });
+
+      it('should transition state to Connecting', () => {
+        mediaStream.setInputTracksFromStream = () => Promise.resolve();
+        conn.accept();
+        return (() => Promise.resolve())().then(() => {
+          assert.equal(conn.status(), Connection.State.Connecting);
         });
       });
 
@@ -441,6 +459,13 @@ describe('Connection', function() {
           sinon.assert.calledWith(publisher.error, 'get-user-media', 'denied');
         });
       });
+
+      it('should transition status back to pending', () => {
+        conn.accept({ foo: 'bar' } as MediaTrackConstraints);
+        return wait.then(() => {
+          assert.equal(conn.status(), Connection.State.Pending);
+        });
+      });
     });
 
     context('when getInputStream is present and fails without 31208', () => {
@@ -464,6 +489,13 @@ describe('Connection', function() {
         conn.accept({ foo: 'bar' } as MediaTrackConstraints);
         return wait.then(() => {
           sinon.assert.calledWith(publisher.error, 'get-user-media', 'failed');
+        });
+      });
+
+      it('should transition status back to pending', () => {
+        conn.accept({ foo: 'bar' } as MediaTrackConstraints);
+        return wait.then(() => {
+          assert.equal(conn.status(), Connection.State.Pending);
         });
       });
     });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6897](https://issues.corp.twilio.com/browse/CLIENT-6897)

### Description

Dont hangup on getUserMedia failure

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
