### PR TITLE
CLIENT-6957 | Sending Local ICE candidates to insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements
 * Added additional triggers for media reconnection. ICE Restarts will be issued and will follow retry policy as defined in [media reconnection](https://www.twilio.com/docs/voice/client/javascript/connection#onreconnecting-handlererror) API.
   * ICE Gathering Failure - happens when ICE Gathering state transitions to `complete` and no ICE Candidates were successfully gathered.
   * ICE Gathering Timeout - happens when ICE Gathering exceeded 15 seconds and no ICE candidates were successfully gathered.
+* We now log ICE Candidates to insights during ICE gathering phase. (CLIENT-6957)
 
 1.9.5 (Nov 5, 2019)
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Improvements
 * Added additional triggers for media reconnection. ICE Restarts will be issued and will follow retry policy as defined in [media reconnection](https://www.twilio.com/docs/voice/client/javascript/connection#onreconnecting-handlererror) API.
   * ICE Gathering Failure - happens when ICE Gathering state transitions to `complete` and no ICE Candidates were successfully gathered.
   * ICE Gathering Timeout - happens when ICE Gathering exceeded 15 seconds and no ICE candidates were successfully gathered.
-* We now log ICE Candidates to insights during ICE gathering phase. (CLIENT-6957)
+* Locally gathered ICE candidates are now reported to Insights. (CLIENT-6957)
 
 1.9.5 (Nov 5, 2019)
 ===================

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -334,7 +334,7 @@ class Connection extends EventEmitter {
     };
 
     this.mediaStream.onicecandidate = (candidate: IRTCIceCandidate): void => {
-      const payload = new RTCLocalIceCandidate(candidate).payload();
+      const payload = new RTCLocalIceCandidate(candidate).toPayload();
       this._publisher.debug('ice-candidate', 'ice-candidate', payload, this);
     };
 

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events';
 import Device from './device';
 import DialtonePlayer from './dialtonePlayer';
 import { GeneralErrors, InvalidArgumentError, MediaErrors, TwilioError } from './errors';
-import { IRTCIceCandidate, RTCLocalIceCandidate } from './rtc/candidate';
+import { RTCIceCandidate, RTCLocalIceCandidate } from './rtc/candidate';
 import RTCSample from './rtc/sample';
 import RTCWarning from './rtc/warning';
 import StatsMonitor from './statsMonitor';
@@ -333,7 +333,7 @@ class Connection extends EventEmitter {
       this._publisher.post(level, 'pc-connection-state', state, null, this);
     };
 
-    this.mediaStream.onicecandidate = (candidate: IRTCIceCandidate): void => {
+    this.mediaStream.onicecandidate = (candidate: RTCIceCandidate): void => {
       const payload = new RTCLocalIceCandidate(candidate).toPayload();
       this._publisher.debug('ice-candidate', 'ice-candidate', payload, this);
     };

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from 'events';
 import Device from './device';
 import DialtonePlayer from './dialtonePlayer';
 import { GeneralErrors, InvalidArgumentError, MediaErrors, TwilioError } from './errors';
+import { BrowserIceCandidate, getRTCIceCandidate, RTCIceCandidate } from './rtc/candidate';
 import RTCSample from './rtc/sample';
 import RTCWarning from './rtc/warning';
 import StatsMonitor from './statsMonitor';
@@ -142,6 +143,11 @@ class Connection extends EventEmitter {
   private readonly _direction: Connection.CallDirection;
 
   /**
+   * The getRTCIceCandidate method to use for this {@link Connection}
+   */
+  private _getRTCIceCandidate: (candidate: BrowserIceCandidate) => RTCIceCandidate;
+
+  /**
    * The number of times input volume has been the same consecutively.
    */
   private _inputVolumeStreak: number = 0;
@@ -265,6 +271,8 @@ class Connection extends EventEmitter {
       : this.options.warnings ? LogLevel.Warn
       : LogLevel.Off);
 
+    this._getRTCIceCandidate = this.options.getRTCIceCandidate || getRTCIceCandidate;
+
     this._mediaReconnectBackoff = Backoff.exponential(BACKOFF_CONFIG);
     this._mediaReconnectBackoff.on('ready', () => this.mediaStream.iceRestart());
 
@@ -330,6 +338,10 @@ class Connection extends EventEmitter {
         level = dtlsTransport && dtlsTransport.state === 'failed' ? 'error' : 'warning';
       }
       this._publisher.post(level, 'pc-connection-state', state, null, this);
+    };
+
+    this.mediaStream.onicecandidate = (candidate: BrowserIceCandidate): void => {
+      this._publisher.debug('ice-candidate', 'ice-candidate', this._getRTCIceCandidate(candidate), this);
     };
 
     this.mediaStream.oniceconnectionstatechange = (state: string): void => {
@@ -1616,6 +1628,11 @@ namespace Connection {
      * A method that returns the current input MediaStream set on {@link Device}.
      */
     getInputStream?: () => MediaStream;
+
+    /**
+     * A method to parse an ICE Candidate gathered by the browser and returns a RTCIceCandidate object
+     */
+    getRTCIceCandidate?: (candidate: BrowserIceCandidate) => RTCIceCandidate;
 
     /**
      * A method that returns the current SinkIDs set on {@link Device}.

--- a/lib/twilio/rtc/candidate.ts
+++ b/lib/twilio/rtc/candidate.ts
@@ -1,0 +1,90 @@
+/**
+ * @module Voice
+ * @internalapi
+ */
+
+/**
+ * Parse an ICE candidate gathered by the browser and returns a RTCIceCandidate object
+ * @param candidate ICE candidate coming from the browser
+ * @returns RTCIceCandidate object
+ */
+export const getRTCIceCandidate = (ca: BrowserIceCandidate): RTCIceCandidate => {
+  let cost;
+  const parts = ca.candidate.split('network-cost ');
+
+  if (parts[1]) {
+    cost = parseInt(parts[1], 10);
+  }
+
+  return {
+    'candidate_type': ca.type,
+    'deleted': false,
+    'ip': ca.ip || ca.address,
+    'is_remote': false,
+    'network-cost': cost,
+    'port': ca.port,
+    'priority': ca.priority,
+    'protocol': ca.protocol,
+    'transport_id': ca.sdpMid,
+  };
+};
+
+/**
+ * Represents an ICE candidate coming from the browser
+ * @private
+ */
+export type BrowserIceCandidate = any;
+
+/**
+ * ICE Candidate gathered during ICE gathering phase
+ * @private
+ */
+export interface RTCIceCandidate {
+  /**
+   * Candidate's type
+   * https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidateType
+   */
+  candidate_type: string;
+
+  /**
+   * Whether this is deleted from the list of candidate gathered
+   */
+  deleted: boolean;
+
+  /**
+   * Candidate's IP address
+   */
+  ip: string;
+
+  /**
+   * Whether this is a remote candidate
+   */
+  is_remote: boolean;
+
+  /**
+   * A number from 0 to 999 indicating the cost of network
+   * where larger values indicate a stronger preference for not using that network
+   */
+  'network-cost': number | undefined;
+
+  /**
+   * Candidate's port number
+   */
+  port: number;
+
+  /**
+   * A number indicating candidate's priority
+   */
+  priority: number;
+
+  /**
+   * Candidate's protocol - udp or tcp
+   */
+  protocol: string;
+
+  /**
+   * Also known as sdpMid, specifying the candidate's media stream identification tag which uniquely
+   * identifies the media stream within the component with which the candidate is associated
+   */
+  transport_id: string;
+}

--- a/lib/twilio/rtc/candidate.ts
+++ b/lib/twilio/rtc/candidate.ts
@@ -24,7 +24,7 @@ interface RTCIceCandidatePayload {
  * https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate
  * @private
  */
-export type IRTCIceCandidate = any;
+export type RTCIceCandidate = any;
 
 /**
  * {@link RTCIceCandidate} parses an ICE candidate gathered by the browser
@@ -83,7 +83,7 @@ export class RTCLocalIceCandidate {
    * @constructor
    * @param iceCandidate RTCIceCandidate coming from the browser
    */
-  constructor(iceCandidate: IRTCIceCandidate) {
+  constructor(iceCandidate: RTCIceCandidate) {
     let cost;
     const parts = iceCandidate.candidate.split('network-cost ');
 

--- a/lib/twilio/rtc/candidate.ts
+++ b/lib/twilio/rtc/candidate.ts
@@ -7,7 +7,7 @@
  * Payload bject we send to insights
  * @private
  */
-type IRTCIceCandidateInsights = any;
+type RTCIceCandidatePayload = any;
 
 /**
  * Represents an ICE candidate coming from the browser
@@ -93,7 +93,7 @@ export class RTCLocalIceCandidate {
   /**
    * Get the payload object for insights
    */
-  payload(): IRTCIceCandidateInsights {
+  toPayload(): RTCIceCandidatePayload {
     return {
       'candidate_type': this.candidateType,
       'deleted': this.deleted,

--- a/lib/twilio/rtc/candidate.ts
+++ b/lib/twilio/rtc/candidate.ts
@@ -4,10 +4,20 @@
  */
 
 /**
- * Payload bject we send to insights
+ * Payload object we send to insights
  * @private
  */
-type RTCIceCandidatePayload = any;
+interface RTCIceCandidatePayload {
+  candidate_type: string,
+  deleted: boolean,
+  ip: string,
+  is_remote: boolean,
+  'network-cost': number | undefined,
+  port: number,
+  priority: number,
+  protocol: string,
+  transport_id: string,
+};
 
 /**
  * Represents an ICE candidate coming from the browser

--- a/lib/twilio/rtc/candidate.ts
+++ b/lib/twilio/rtc/candidate.ts
@@ -8,16 +8,16 @@
  * @private
  */
 interface RTCIceCandidatePayload {
-  candidate_type: string,
-  deleted: boolean,
-  ip: string,
-  is_remote: boolean,
-  'network-cost': number | undefined,
-  port: number,
-  priority: number,
-  protocol: string,
-  transport_id: string,
-};
+  candidate_type: string;
+  deleted: boolean;
+  ip: string;
+  is_remote: boolean;
+  'network-cost': number | undefined;
+  port: number;
+  priority: number;
+  protocol: string;
+  transport_id: string;
+}
 
 /**
  * Represents an ICE candidate coming from the browser

--- a/lib/twilio/rtc/candidate.ts
+++ b/lib/twilio/rtc/candidate.ts
@@ -4,87 +4,106 @@
  */
 
 /**
- * Parse an ICE candidate gathered by the browser and returns a RTCIceCandidate object
- * @param candidate ICE candidate coming from the browser
- * @returns RTCIceCandidate object
+ * Payload bject we send to insights
+ * @private
  */
-export const getRTCIceCandidate = (ca: BrowserIceCandidate): RTCIceCandidate => {
-  let cost;
-  const parts = ca.candidate.split('network-cost ');
-
-  if (parts[1]) {
-    cost = parseInt(parts[1], 10);
-  }
-
-  return {
-    'candidate_type': ca.type,
-    'deleted': false,
-    'ip': ca.ip || ca.address,
-    'is_remote': false,
-    'network-cost': cost,
-    'port': ca.port,
-    'priority': ca.priority,
-    'protocol': ca.protocol,
-    'transport_id': ca.sdpMid,
-  };
-};
+type IRTCIceCandidateInsights = any;
 
 /**
  * Represents an ICE candidate coming from the browser
+ * https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate
  * @private
  */
-export type BrowserIceCandidate = any;
+export type IRTCIceCandidate = any;
 
 /**
- * ICE Candidate gathered during ICE gathering phase
- * @private
+ * {@link RTCIceCandidate} parses an ICE candidate gathered by the browser
+ * and returns a RTCLocalIceCandidate object
  */
-export interface RTCIceCandidate {
+export class RTCLocalIceCandidate {
   /**
    * Candidate's type
    * https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidateType
    */
-  candidate_type: string;
+  private candidateType: string;
 
   /**
    * Whether this is deleted from the list of candidate gathered
    */
-  deleted: boolean;
+  private deleted: boolean = false;
 
   /**
    * Candidate's IP address
    */
-  ip: string;
+  private ip: string;
 
   /**
    * Whether this is a remote candidate
    */
-  is_remote: boolean;
+  private isRemote: boolean = false;
 
   /**
    * A number from 0 to 999 indicating the cost of network
    * where larger values indicate a stronger preference for not using that network
    */
-  'network-cost': number | undefined;
+  private networkCost: number | undefined;
 
   /**
    * Candidate's port number
    */
-  port: number;
+  private port: number;
 
   /**
    * A number indicating candidate's priority
    */
-  priority: number;
+  private priority: number;
 
   /**
    * Candidate's protocol - udp or tcp
    */
-  protocol: string;
+  private protocol: string;
 
   /**
    * Also known as sdpMid, specifying the candidate's media stream identification tag which uniquely
    * identifies the media stream within the component with which the candidate is associated
    */
-  transport_id: string;
+  private transportId: string;
+
+  /**
+   * @constructor
+   * @param iceCandidate RTCIceCandidate coming from the browser
+   */
+  constructor(iceCandidate: IRTCIceCandidate) {
+    let cost;
+    const parts = iceCandidate.candidate.split('network-cost ');
+
+    if (parts[1]) {
+      cost = parseInt(parts[1], 10);
+    }
+
+    this.candidateType = iceCandidate.type;
+    this.ip = iceCandidate.ip || iceCandidate.address;
+    this.networkCost = cost;
+    this.port = iceCandidate.port;
+    this.priority = iceCandidate.priority;
+    this.protocol = iceCandidate.protocol;
+    this.transportId = iceCandidate.sdpMid;
+  }
+
+  /**
+   * Get the payload object for insights
+   */
+  payload(): IRTCIceCandidateInsights {
+    return {
+      'candidate_type': this.candidateType,
+      'deleted': this.deleted,
+      'ip': this.ip,
+      'is_remote': this.isRemote,
+      'network-cost': this.networkCost,
+      'port': this.port,
+      'priority': this.priority,
+      'protocol': this.protocol,
+      'transport_id': this.transportId,
+    };
+  }
 }

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -693,10 +693,10 @@ PeerConnection.prototype._setupChannel = function() {
     const { candidate } = event;
     if (candidate) {
       this._hasIceCandidates = true;
+      this.onicecandidate(candidate);
     }
 
     this.log(`ICE Candidate: ${JSON.stringify(candidate)}`);
-    this.onicecandidate(candidate);
   };
 
   pc.onicegatheringstatechange = () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -74,6 +74,7 @@ require('./pstream');
 require('./sound');
 require('./sdp');
 
+require('./unit/candidate');
 require('./unit/connection');
 require('./unit/device');
 require('./unit/deferred');

--- a/tests/unit/candidate.ts
+++ b/tests/unit/candidate.ts
@@ -1,0 +1,56 @@
+import { getRTCIceCandidate } from '../../lib/twilio/rtc/candidate';
+import * as assert from 'assert';
+
+describe('Candidate', () => {
+  let data: any;
+  let output: any;
+
+  beforeEach(() => {
+    data = {
+      type: 'host',
+      address: '192.168.1.1',
+      candidate: 'network-id 2 network-cost 20',
+      port: 63982,
+      priority: 123,
+      protocol: 'udp',
+      sdpMid: 'audio'
+    };
+
+    output = {
+      candidate_type: 'host',
+      deleted: false,
+      ip: '192.168.1.1',
+      is_remote: false,
+      'network-cost': 20,
+      port: 63982,
+      priority: 123,
+      protocol: 'udp',
+      transport_id: 'audio'
+    };
+  });
+
+  it('Should return valid RTCIceCandidate', () => {
+    assert.deepEqual(getRTCIceCandidate(data), output);
+  });
+
+  it('Should return undefined when a property is not supported', () => {
+    delete data.address;
+    assert.equal(getRTCIceCandidate(data).ip, undefined);
+  });
+
+  it('Should use ip if exists', () => {
+    data.ip = 'foo';
+    assert.equal(getRTCIceCandidate(data).ip, 'foo');
+  });
+
+  it('Should return empty cost if it does not exists', () => {
+    data.candidate = 'foo';
+    assert.equal(getRTCIceCandidate(data)['network-cost'], undefined);
+  });
+
+  it('Should return default values for deleted and remote', () => {
+    const result = getRTCIceCandidate(data);
+    assert(!result.deleted);
+    assert(!result.is_remote);
+  });
+});

--- a/tests/unit/candidate.ts
+++ b/tests/unit/candidate.ts
@@ -30,26 +30,26 @@ describe('Candidate', () => {
   });
 
   it('Should return valid RTCIceCandidate', () => {
-    assert.deepEqual(new RTCLocalIceCandidate(data).payload(), output);
+    assert.deepEqual(new RTCLocalIceCandidate(data).toPayload(), output);
   });
 
   it('Should return undefined when a property is not supported', () => {
     delete data.address;
-    assert.equal(new RTCLocalIceCandidate(data).payload().ip, undefined);
+    assert.equal(new RTCLocalIceCandidate(data).toPayload().ip, undefined);
   });
 
   it('Should use ip if exists', () => {
     data.ip = 'foo';
-    assert.equal(new RTCLocalIceCandidate(data).payload().ip, 'foo');
+    assert.equal(new RTCLocalIceCandidate(data).toPayload().ip, 'foo');
   });
 
   it('Should return empty cost if it does not exists', () => {
     data.candidate = 'foo';
-    assert.equal(new RTCLocalIceCandidate(data).payload()['network-cost'], undefined);
+    assert.equal(new RTCLocalIceCandidate(data).toPayload()['network-cost'], undefined);
   });
 
   it('Should return default values for deleted and remote', () => {
-    const result = new RTCLocalIceCandidate(data).payload();
+    const result = new RTCLocalIceCandidate(data).toPayload();
     assert(!result.deleted);
     assert(!result.is_remote);
   });

--- a/tests/unit/candidate.ts
+++ b/tests/unit/candidate.ts
@@ -1,4 +1,4 @@
-import { getRTCIceCandidate } from '../../lib/twilio/rtc/candidate';
+import { RTCLocalIceCandidate } from '../../lib/twilio/rtc/candidate';
 import * as assert from 'assert';
 
 describe('Candidate', () => {
@@ -30,26 +30,26 @@ describe('Candidate', () => {
   });
 
   it('Should return valid RTCIceCandidate', () => {
-    assert.deepEqual(getRTCIceCandidate(data), output);
+    assert.deepEqual(new RTCLocalIceCandidate(data).payload(), output);
   });
 
   it('Should return undefined when a property is not supported', () => {
     delete data.address;
-    assert.equal(getRTCIceCandidate(data).ip, undefined);
+    assert.equal(new RTCLocalIceCandidate(data).payload().ip, undefined);
   });
 
   it('Should use ip if exists', () => {
     data.ip = 'foo';
-    assert.equal(getRTCIceCandidate(data).ip, 'foo');
+    assert.equal(new RTCLocalIceCandidate(data).payload().ip, 'foo');
   });
 
   it('Should return empty cost if it does not exists', () => {
     data.candidate = 'foo';
-    assert.equal(getRTCIceCandidate(data)['network-cost'], undefined);
+    assert.equal(new RTCLocalIceCandidate(data).payload()['network-cost'], undefined);
   });
 
   it('Should return default values for deleted and remote', () => {
-    const result = getRTCIceCandidate(data);
+    const result = new RTCLocalIceCandidate(data).payload();
     assert(!result.deleted);
     assert(!result.is_remote);
   });

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -15,6 +15,7 @@ describe('Connection', function() {
   let clock: SinonFakeTimers;
   let config: Connection.Config;
   let conn: Connection;
+  let getRTCIceCandidate: any;
   let getUserMedia: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
   let mediaStream: any;
   let monitor: any;
@@ -54,6 +55,7 @@ describe('Connection', function() {
     clock = sinon.useFakeTimers(Date.now());
 
     audioHelper = createEmitterStub(require('../../lib/twilio/audiohelper').default);
+    getRTCIceCandidate = sinon.stub().returns('foo');
     getUserMedia = sinon.spy(() => Promise.resolve(new MediaStream()));
     pstream = createEmitterStub(require('../../lib/twilio/pstream').PStream);
     publisher = createEmitterStub(require('../../lib/twilio/eventpublisher'));
@@ -81,6 +83,7 @@ describe('Connection', function() {
       MediaStream: MediaHandler,
       StatsMonitor,
       enableIceRestart: true,
+      getRTCIceCandidate,
     };
 
     conn = new Connection(config, options);
@@ -899,6 +902,14 @@ describe('Connection', function() {
         });
 
         mediaStream.onvolume(123, 456);
+      });
+    });
+
+    describe('mediaStream.onicecandidate', () => {
+      it('should publish a debug event', () => {
+        mediaStream.onicecandidate('foo');
+        sinon.assert.calledWith(getRTCIceCandidate, 'foo');
+        sinon.assert.calledWith(publisher.debug, 'ice-candidate', 'ice-candidate', 'foo');
       });
     });
 

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -15,7 +15,6 @@ describe('Connection', function() {
   let clock: SinonFakeTimers;
   let config: Connection.Config;
   let conn: Connection;
-  let getRTCIceCandidate: any;
   let getUserMedia: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
   let mediaStream: any;
   let monitor: any;
@@ -55,7 +54,6 @@ describe('Connection', function() {
     clock = sinon.useFakeTimers(Date.now());
 
     audioHelper = createEmitterStub(require('../../lib/twilio/audiohelper').default);
-    getRTCIceCandidate = sinon.stub().returns('foo');
     getUserMedia = sinon.spy(() => Promise.resolve(new MediaStream()));
     pstream = createEmitterStub(require('../../lib/twilio/pstream').PStream);
     publisher = createEmitterStub(require('../../lib/twilio/eventpublisher'));
@@ -83,7 +81,6 @@ describe('Connection', function() {
       MediaStream: MediaHandler,
       StatsMonitor,
       enableIceRestart: true,
-      getRTCIceCandidate,
     };
 
     conn = new Connection(config, options);
@@ -907,9 +904,8 @@ describe('Connection', function() {
 
     describe('mediaStream.onicecandidate', () => {
       it('should publish a debug event', () => {
-        mediaStream.onicecandidate('foo');
-        sinon.assert.calledWith(getRTCIceCandidate, 'foo');
-        sinon.assert.calledWith(publisher.debug, 'ice-candidate', 'ice-candidate', 'foo');
+        mediaStream.onicecandidate({ candidate: 'foo' });
+        sinon.assert.calledWith(publisher.debug, 'ice-candidate', 'ice-candidate');
       });
     });
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6957](https://issues.corp.twilio.com/browse/CLIENT-6957)

### Description

Sending ICE candidates to insights.
`url` is not supported by the browsers. We cannot get stun/turn url for each candidate.

Only chrome supports these properties, as shown in the PR. Other browsers will only publish properties that are supported. See https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
