### PR TITLE
Add circle ci config to trigger QE e2e tests when RC is cut

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2.1
+
+jobs:
+  trigger-qe-tests:
+    docker:
+    - image: circleci/node:latest
+    steps:
+    - run:
+        name: Trigger QE tests
+        command: |
+          curl --silent --output /dev/null -u "$CIRCLECI_API_AUTH_TOKEN": -X POST \
+          --header "Content-Type: application/json" \
+          -d '{"branch":"'v${CIRCLE_TAG:0:1}'","parameters":{"sdk_version":"'$CIRCLE_TAG'","is_rc":true}}' \
+          $SDKS_QE_CIRCLECI_VOICE_JS_TESTS_ENDPOINT
+workflows:
+  release-candidate:
+      jobs:
+      - trigger-qe-tests:
+          filters:
+            tags:
+              only:
+              - /^\d+\.\d+\.\d+-rc\d+$/
+              - /^\d+\.\d+\.\d+-preview\d+-rc\d+$/
+              - /^\d+\.\d+\.\d+-beta\d+-rc\d+$/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
Adding a CircleCI config to automatically trigger QE tests when RC is cut. @charliesantos could you please +1 the PR so that I can get started with setting up a circle ci job for triggering QE tests when RC is cut?

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
