### PR TITLE
CLIENT-6913 | Sending DTLS state changes to insights

### DIFF
--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -324,6 +324,11 @@ class Connection extends EventEmitter {
       this.emit('volume', inputVolume, outputVolume);
     };
 
+    this.mediaStream.ondtlstransportstatechange = (state: string): void => {
+      const level = state === 'failed' ? 'error' : 'debug';
+      this._publisher.post(level, 'dtls-transport-state', state, null, this);
+    };
+
     this.mediaStream.onpcconnectionstatechange = (state: string): void => {
       let level = 'debug';
       const dtlsTransport = this.mediaStream.getRTCDtlsTransport();

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -41,6 +41,7 @@ function PeerConnection(audioHelper, pstream, getUserMedia, options) {
   this.onconnected = noop;
   this.onreconnected = noop;
   this.onsignalingstatechange = noop;
+  this.ondtlstransportstatechange = noop;
   this.onicegatheringfailure = noop;
   this.onicegatheringstatechange = noop;
   this.oniceconnectionstatechange = noop;
@@ -767,6 +768,27 @@ PeerConnection.prototype._removeReconnectionListeners = function() {
 };
 
 /**
+ * Setup a listener for RTCDtlsTransport to capture state changes events
+ * @private
+ */
+PeerConnection.prototype._setupRTCDtlsTransportListener = function() {
+  const dtlsTransport = this.getRTCDtlsTransport();
+
+  if (!dtlsTransport || dtlsTransport.onstatechange) {
+    return;
+  }
+
+  const handler = () => {
+    this.log(`dtlsTransportState is "${dtlsTransport.state}"`);
+    this.ondtlstransportstatechange(dtlsTransport.state);
+  };
+
+  // Publish initial state
+  handler();
+  dtlsTransport.onstatechange = handler;
+};
+
+/**
  * Restarts ICE for the current connection
  * ICE Restart failures are ignored. Retries are managed in Connection
  * @private
@@ -859,6 +881,8 @@ PeerConnection.prototype.makeOutgoingCall = function(token, params, callsid, rtc
         callsid: self.callSid,
         twilio: params ? { params } : { }
       });
+
+      self._setupRTCDtlsTransportListener();
     }
   }
 
@@ -891,6 +915,7 @@ PeerConnection.prototype.answerIncomingCall = function(callSid, sdp, rtcConstrai
         self._setEncodingParameters(self.options.dscp);
       }
       onMediaStarted(self.version.pc);
+      self._setupRTCDtlsTransportListener();
     }
   }
   function onAnswerError(err) {

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -889,6 +889,18 @@ describe('Connection', function() {
       });
     });
 
+    describe('mediaStream.ondtlstransportstatechange', () => {
+      it('should publish an error event if state is failed', () => {
+        mediaStream.ondtlstransportstatechange('failed');
+        sinon.assert.calledWith(publisher.post, 'error', 'dtls-transport-state', 'failed');
+      });
+
+      it('should publish a debug event if state is not failed', () => {
+        mediaStream.ondtlstransportstatechange('foo');
+        sinon.assert.calledWith(publisher.post, 'debug', 'dtls-transport-state', 'foo');
+      });
+    });
+
     describe('mediaStream.oniceconnectionstatechange', () => {
       it('should publish an error event if state is failed', () => {
         mediaStream.oniceconnectionstatechange('failed');


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-6913](https://issues.corp.twilio.com/browse/CLIENT-6913)

### Description

Publishes dtls transport states to insights with the following values:
https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport/state
RTC insights specs: https://code.hq.twilio.com/client/rtc-insights-spec#dtls-transport-state-events

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
