### PR TITLE
CLIENT-7385 | Using twiml app that can record and play audio

### DIFF
--- a/PREFLIGHT_TWIML.md
+++ b/PREFLIGHT_TWIML.md
@@ -1,0 +1,46 @@
+Preflight Test TwiML App
+=========================
+
+`Device.testPreflight(token, options)` API requires a TwiML app that can record an audio from a microphone and the ability to play the recorded audio back to the browser. In order to achieve this, we need two TwiML endpoints: one to capture and record the audio, and another one to play the recorded audio.
+
+TwiML Bins
+----------
+
+In this example, we will use TwiML Bins for our TwiML app. Start by going to the [TwiML Bin](https://www.twilio.com/console/twiml-bins) page in the Twilio Console.
+
+### TwiML App - Playback
+Create a new TwiML Bin with the plus button on that screen and use `Playback` as the friendly name. Then use the following template under the TwiML section.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Response>
+  <Say>You said:</Say>
+  <Play loop="1">{{RecordingUrl}}</Play>
+  <Say>Hanging up now.</Say>
+</Response>
+```
+
+Go ahead and click the **Create** button and copy the TwiML Bin's url located at the top of the screen.
+
+### TwiML App - Record
+Using the [TwiML Bin](https://www.twilio.com/console/twiml-bins) page, let's create another TwiML Bin by clicking the plus button on that screen and use `Record` as the friendly name. Then replace the action url in the following template with your **TwiML Bin's Playback** url that you created previously. Let's use this template under the TwiML section.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Response>
+  <Say>Record a message in 3, 2, 1</Say>
+  <Record maxLength="3" action="https://my-record-twiml-url"></Record>
+  <Say>Did not detect a message to record</Say>
+</Response>
+```
+
+Go ahead and click the **Create** button and copy the TwiML Bin's url located at the top of the screen.
+
+Creating the TwiML App
+-----------------------
+
+Now that we have created our TwiML Bins, let's create our TwiML app by going to the [TwiML Apps](https://www.twilio.com/console/voice/twiml/apps) page. Click the plus button on that screen and enter a friendly name that you prefer. Under Voice request url, enter the **TwiML Bin's Record** url that you created in the previous section, and then click the **Create** button.
+
+On that same page, open the TwiML app that you just created by clicking on it and make note of the `SID`. You can now use this TwiML app to generate your [token](https://www.twilio.com/docs/iam/access-tokens) when calling `Device.testPreflight(token, options)` API.

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -208,8 +208,8 @@ class Device extends EventEmitter {
    * @param [token] - A Twilio JWT token string
    * @param [options] - Options passed to {@link PreflightTest} constructor
    */
-  static testPreflight(token: string, options: PreflightTest.PreflightOptions): PreflightTest {
-    return new PreflightTest(token, options);
+  static testPreflight(token: string, options?: PreflightTest.PreflightOptions): PreflightTest {
+    return new PreflightTest(token, options || {});
   }
 
   /**

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -89,7 +89,6 @@ describe('PreflightTest', () => {
     deviceFactory = getDeviceFactory(deviceContext)
 
     options = {
-      connectParams: {},
       deviceFactory
     };
 
@@ -107,15 +106,6 @@ describe('PreflightTest', () => {
       sinon.assert.calledWith(deviceContext.setup, 'foo', {
         codecPreferences: options.codecPreferences,
         debug: false
-      });
-    });
-
-    it('should pass connectParams on connect', () => {
-      options.connectParams = 'foo';
-      const preflight = new PreflightTest('foo', options);
-      device.emit('ready');
-      return wait().then(() => {
-        sinon.assert.calledWith(deviceContext.connect, 'foo');
       });
     });
   });
@@ -224,26 +214,16 @@ describe('PreflightTest', () => {
   });
 
   describe('on completed and destroy device', () => {
-    it('should end call after 15s by default', () => {
+    it('should end call after device disconnects', () => {
       const onCompleted = sinon.stub();
       const preflight = new PreflightTest('foo', options);
       preflight.on('completed', onCompleted);
       device.emit('ready');
-      clock.tick(15000);
+      clock.tick(14000);
+      device.emit('disconnect');
+      clock.tick(1000);
       device.emit('offline');
       assert(preflight.endTime! - preflight.startTime === 15000);
-      sinon.assert.calledOnce(deviceContext.destroy);
-      sinon.assert.called(onCompleted);
-    });
-
-    it('should end call after 10s and destroy device', () => {
-      options.callSeconds = 10;
-      const onCompleted = sinon.stub();
-      const preflight = new PreflightTest('foo', options);
-      preflight.on('completed', onCompleted);
-      device.emit('ready');
-      clock.tick(10000);
-      device.emit('offline');
       sinon.assert.calledOnce(deviceContext.destroy);
       sinon.assert.called(onCompleted);
     });
@@ -253,7 +233,9 @@ describe('PreflightTest', () => {
       const preflight = new PreflightTest('foo', options);
       preflight.on('completed', onCompleted);
       device.emit('ready');
-      clock.tick(15000);
+      clock.tick(14000);
+      device.emit('disconnect');
+      clock.tick(1000);
       device.emit('offline');
 
       assert.equal(device.eventNames().length, 0);
@@ -347,7 +329,9 @@ describe('PreflightTest', () => {
       connection.mediaStream.ondtlstransportstatechange('connected');
       connection.mediaStream.oniceconnectionstatechange('connected');
 
-      clock.tick(14000);
+      clock.tick(13000);
+      device.emit('disconnect');
+      clock.tick(1000);
       device.emit('offline');
     });
   });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7385](https://issues.corp.twilio.com/browse/CLIENT-7385)

### Description

This PR removes the `connectParams` and `callSeconds` requirement. We now provide a twiml app that allows audio recording and playback. Also provided twiml template and instructions for customers who wants to replicate the twiml.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
