### PR TITLE
CLIENT-4533 Unit tests for PStream/VSP payloads.

### DIFF
--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -783,8 +783,7 @@ class Connection extends EventEmitter {
       return;
     }
 
-    const payload = { callsid: this.parameters.CallSid };
-    this.pstream.publish('reject', payload);
+    this.pstream.reject(this.parameters.CallSid);
     this._status = Connection.State.Closed;
     this.emit('reject');
     this.mediaStream.reject(this.parameters.CallSid);
@@ -855,10 +854,7 @@ class Connection extends EventEmitter {
     this._log.info('Sending digits over PStream');
 
     if (this.pstream !== null && this.pstream.status !== 'disconnected') {
-      this.pstream.publish('dtmf', {
-        callsid: this.parameters.CallSid,
-        dtmf: digits,
-      });
+      this.pstream.dtmf(this.parameters.CallSid, digits);
     } else {
       const error = {
         code: 31000,
@@ -1020,11 +1016,7 @@ class Connection extends EventEmitter {
     if (this.pstream !== null && this.pstream.status !== 'disconnected' && this.sendHangup) {
       const callsid: string | undefined = this.parameters.CallSid || this.outboundConnectionId;
       if (callsid) {
-        const payload: Partial<Record<string, string>> = { callsid };
-        if (message) {
-          payload.message = message;
-        }
-        this.pstream.publish('hangup', payload);
+        this.pstream.hangup(callsid, message);
       }
     }
 

--- a/lib/twilio/pstream.js
+++ b/lib/twilio/pstream.js
@@ -170,6 +170,19 @@ PStream.prototype.register = function(mediaCapabilities) {
   this._publish('register', regPayload, true);
 };
 
+PStream.prototype.invite = function(sdp, callsid, params) {
+  const payload = {
+    callsid,
+    sdp,
+    twilio: params ? { params } : {}
+  };
+  this._publish('invite', payload, true);
+};
+
+PStream.prototype.answer = function(sdp, callsid) {
+  this._publish('answer', { sdp, callsid }, true);
+};
+
 PStream.prototype.reinvite = function(sdp, callsid) {
   this._publish('reinvite', { sdp, callsid }, false);
 };

--- a/lib/twilio/pstream.js
+++ b/lib/twilio/pstream.js
@@ -183,6 +183,19 @@ PStream.prototype.answer = function(sdp, callsid) {
   this._publish('answer', { sdp, callsid }, true);
 };
 
+PStream.prototype.dtmf = function(callsid, digits) {
+  this._publish('dtmf', { callsid, dtmf: digits }, true);
+};
+
+PStream.prototype.hangup = function(callsid, message) {
+  const payload = message ? { callsid, message } : { callsid };
+  this._publish('hangup', payload, true);
+};
+
+PStream.prototype.reject = function(callsid) {
+  this._publish('reject', { callsid }, true);
+};
+
 PStream.prototype.reinvite = function(sdp, callsid) {
   this._publish('reinvite', { sdp, callsid }, false);
 };

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -875,12 +875,7 @@ PeerConnection.prototype.makeOutgoingCall = function(token, params, callsid, rtc
 
   function onOfferSuccess() {
     if (self.status !== 'closed') {
-      self.pstream.publish('invite', {
-        sdp: self.version.getSDP(),
-        callsid: self.callSid,
-        twilio: params ? { params } : { }
-      });
-
+      self.pstream.invite(self.version.getSDP(), self.callSid, params);
       self._setupRTCDtlsTransportListener();
     }
   }
@@ -906,10 +901,7 @@ PeerConnection.prototype.answerIncomingCall = function(callSid, sdp, rtcConstrai
   const self = this;
   function onAnswerSuccess() {
     if (self.status !== 'closed') {
-      self.pstream.publish('answer', {
-        callsid: callSid,
-        sdp: self.version.getSDP()
-      });
+      self.pstream.answer(self.version.getSDP(), callSid);
       if (self.options) {
         self._setEncodingParameters(self.options.dscp);
       }

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -57,7 +57,9 @@ root.navigator = {
   mediaDevices: {
     getUserMedia() { return Promise.resolve() },
     enumerateDevices() { return Promise.resolve([]) },
-  }
+  },
+  platform: 'platform',
+  userAgent: 'userAgent'
 };
 
 root.RTCPeerConnection = root.window.RTCPeerConnection = function() { };

--- a/tests/mock/WSTransport.js
+++ b/tests/mock/WSTransport.js
@@ -1,0 +1,17 @@
+const sinon = require('sinon');
+const WSTransport = require('../../lib/twilio/wstransport').default;
+
+/**
+ * Mock a {@link WSTransport}.
+ * @returns {Sinon.SinonStubbedInstance<WSTransport>}
+ * @constructor
+ */
+function MockWSTransport() {
+  const stub = sinon.createStubInstance(WSTransport);
+  stub.emit.callThrough();
+  stub.on.callThrough();
+  stub.removeListener.callThrough();
+  return stub;
+}
+
+module.exports = MockWSTransport;

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -489,7 +489,7 @@ describe('PeerConnection', () => {
         status: 'closed',
         onerror: sinon.stub(),
         pstream: {
-          publish: sinon.stub()
+          answer: sinon.stub()
         }
       };
       toTest = METHOD.bind(
@@ -538,8 +538,8 @@ describe('PeerConnection', () => {
       context.status = false;
       toTest();
       assert(context._initializeMediaStream.calledWithExactly(eConstraints, eIceServers));
-      assert(context.pstream.publish.calledWithExactly('answer', {callsid: eCallSid, sdp: sdp1}));
-      assert(context.pstream.publish.calledOn(context.pstream));
+      assert(context.pstream.answer.calledWithExactly(sdp1, eCallSid));
+      assert(context.pstream.answer.calledOn(context.pstream));
       assert(version.processSDP.calledOnce);
       assert(version.processSDP.calledWithExactly(undefined, undefined, eSDP, {audio: true}, sinon.match.func, sinon.match.func));
       assert(version.getSDP.calledWithExactly());
@@ -565,7 +565,7 @@ describe('PeerConnection', () => {
       assert.equal(rVal.info.twilioError.code, 53402);
 
       assert(version.processSDP.calledWithExactly(undefined, undefined, eSDP, {audio: true}, sinon.match.func, sinon.match.func));
-      assert.equal(context.pstream.publish.called, false);
+      assert.equal(context.pstream.answer.called, false);
       assert.equal(version.getSDP.called, false);
       assert.equal(callback.called, false);
       sinon.assert.notCalled(context._setupRTCDtlsTransportListener);
@@ -583,7 +583,7 @@ describe('PeerConnection', () => {
       assert.equal(rVal.info.twilioError.code, 53402);
 
       assert(version.processSDP.calledWithExactly(undefined, undefined, eSDP, {audio: true}, sinon.match.func, sinon.match.func));
-      assert.equal(context.pstream.publish.called, false);
+      assert.equal(context.pstream.answer.called, false);
       assert.equal(version.getSDP.called, false);
       sinon.assert.notCalled(context._setEncodingParameters);
       assert.equal(callback.called, false);
@@ -808,7 +808,7 @@ describe('PeerConnection', () => {
           once: sinon.stub(),
           on: sinon.stub(),
           removeListener: sinon.stub(),
-          publish: sinon.stub()
+          invite: sinon.stub()
         },
         device: {
           token: null
@@ -848,12 +848,12 @@ describe('PeerConnection', () => {
       assert(version.createOffer.calledOnce);
       assert(version.createOffer.calledWithExactly(undefined, undefined, {audio: true}, sinon.match.func, sinon.match.func));
       assert.equal(callback.called, false);
-      assert.equal(context.pstream.publish.called, false);
+      assert.equal(context.pstream.invite.called, false);
       assert(context.pstream.on.calledWithExactly('answer', sinon.match.func));
       sinon.assert.notCalled(context._setupRTCDtlsTransportListener);
     });
 
-    it('Should call onOfferSuccess and pstream publish when createOffer calls success callback and status is not closed', () => {
+    it('Should call onOfferSuccess and pstream invite when createOffer calls success callback and status is not closed', () => {
       context.status = 'not closed';
       version.createOffer.callsArg(3);
       toTest();
@@ -861,14 +861,8 @@ describe('PeerConnection', () => {
       assert(version.createOffer.calledOnce);
       assert(version.createOffer.calledWithExactly(undefined, undefined, {audio: true}, sinon.match.func, sinon.match.func));
       assert.equal(callback.called, false);
-      assert(context.pstream.publish.calledOnce);
-      assert(context.pstream.publish.calledWithExactly('invite', {
-        sdp: eSDP,
-        callsid: eCallSid,
-        twilio: {
-          params: eParams
-        }
-      }));
+      assert(context.pstream.invite.calledOnce);
+      assert(context.pstream.invite.calledWithExactly(eSDP, eCallSid, eParams));
       assert(version.getSDP.calledOnce);
       assert(version.getSDP.calledWithExactly());
       assert(context.pstream.on.calledWithExactly('answer', sinon.match.func));
@@ -884,14 +878,8 @@ describe('PeerConnection', () => {
       assert(version.createOffer.calledOnce);
       assert(version.createOffer.calledWithExactly(undefined, undefined, {audio: true}, sinon.match.func, sinon.match.func));
       assert.equal(callback.called, false);
-      assert(context.pstream.publish.calledOnce);
-      assert(context.pstream.publish.calledWithExactly('invite', {
-        sdp: eSDP,
-        callsid: eCallSid,
-        twilio: {
-          params: eParams
-        }
-      }));
+      assert(context.pstream.invite.calledOnce);
+      assert(context.pstream.invite.calledWithExactly(eSDP, eCallSid, eParams));
       assert(version.getSDP.calledOnce);
       assert(version.getSDP.calledWithExactly());
       assert(context.pstream.on.calledWithExactly('answer', sinon.match.func));
@@ -1301,7 +1289,7 @@ describe('PeerConnection', () => {
         sinon.assert.callCount(context._onMediaConnectionStateChange, 1);
         sinon.assert.calledWith(context._onMediaConnectionStateChange, currentState);
       });
-  
+
       it(`Should call _onMediaConnectionStateChange when pc.connectionState transitions to "${currentState}" state`, () => {
         version.pc.connectionState = currentState;
         toTest();

--- a/tests/pstream.js
+++ b/tests/pstream.js
@@ -36,8 +36,8 @@ describe('PStream', () => {
         payload: {
           browserinfo: {
             browser: {
-              platform: 'unknown',
-              userAgent: 'unknown',
+              platform: navigator.platform,
+              userAgent: navigator.userAgent,
             },
             p: 'browser',
             plugin: 'rtc',
@@ -175,8 +175,8 @@ describe('PStream', () => {
         payload: {
           browserinfo: {
             browser: {
-              platform: 'unknown',
-              userAgent: 'unknown',
+              platform: navigator.platform,
+              userAgent: navigator.userAgent,
             },
             p: 'browser',
             plugin: 'rtc',
@@ -185,22 +185,6 @@ describe('PStream', () => {
           token: 'foobar',
         },
         type: 'listen',
-        version: '1.5'
-      });
-    });
-  });
-
-  describe('register', () => {
-    it('should return undefined', () => {
-      assert.equal(pstream.register(), undefined);
-    });
-
-    it('should send a REGISTER with the specified media capabilities', () => {
-      pstream.register({ foo: 'bar' });
-      assert.equal(pstream.transport.send.callCount, 1);
-      assert.deepEqual(JSON.parse(pstream.transport.send.args[0][0]), {
-        payload: { media: { foo: 'bar' } },
-        type: 'register',
         version: '1.5'
       });
     });
@@ -263,6 +247,13 @@ describe('PStream', () => {
   });
 
   [
+    ['register', [
+      {
+        args: [{ audio: true }],
+        payload: { media: { audio: true } },
+        scenario: 'called with media capabilities'
+      }
+    ]],
     ['invite', [
       {
         args: ['bar', 'foo', ''],
@@ -320,6 +311,10 @@ describe('PStream', () => {
       const shouldRetry = method !== 'reinvite';
       scenarios.forEach(({ args, payload, scenario }) => {
         context(scenario, () => {
+          it('should return undefined', () => {
+            assert.equal(pstream[method](...args), undefined);
+          });
+
           it(`should publish with${shouldRetry ? '' : 'out'} retry`, () => {
             const stub = sinon.stub(pstream, '_publish');
             pstream[method](...args);

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -488,9 +488,9 @@ describe('Connection', function() {
           (conn as any)['_status'] = state;
         });
 
-        it('should call pstream.publish with hangup', () => {
+        it('should call pstream.hangup', () => {
           conn.disconnect();
-          sinon.assert.calledWith(pstream.publish, 'hangup');
+          sinon.assert.calledWith(pstream.hangup, conn.outboundConnectionId);
         });
 
         it('should call mediaStream.close', () => {
@@ -509,9 +509,9 @@ describe('Connection', function() {
           (conn as any)['_status'] = state;
         });
 
-        it('should not call pstream.publish', () => {
+        it('should not call pstream.hangup', () => {
           conn.disconnect();
-          sinon.assert.notCalled(pstream.publish);
+          sinon.assert.notCalled(pstream.hangup);
         });
 
         it('should not call mediaStream.close', () => {
@@ -689,10 +689,10 @@ describe('Connection', function() {
 
   describe('.reject()', () => {
     context('when state is pending', () => {
-      it('should call pstream.publish with reject', () => {
+      it('should call pstream.reject', () => {
         conn.reject();
-        sinon.assert.calledOnce(pstream.publish);
-        sinon.assert.calledWith(pstream.publish, 'reject', { callsid: conn.parameters.CallSid });
+        sinon.assert.calledOnce(pstream.reject);
+        sinon.assert.calledWith(pstream.reject, conn.parameters.CallSid);
       });
 
       it('should call mediaStream.reject', () => {
@@ -727,9 +727,9 @@ describe('Connection', function() {
           (conn as any)['_status'] = state;
         });
 
-        it('should not call pstream.publish', () => {
+        it('should not call pstream.reject', () => {
           conn.reject();
-          sinon.assert.notCalled(pstream.publish);
+          sinon.assert.notCalled(pstream.reject);
         });
 
         it('should not call mediaStream.reject', () => {
@@ -834,12 +834,9 @@ describe('Connection', function() {
       sinon.assert.callCount(soundcache.get(Device.SoundName.DtmfH).play, 1);
     });
 
-    it('should call pstream.publish if connected', () => {
+    it('should call pstream.dtmf if connected', () => {
       conn.sendDigits('123');
-      sinon.assert.calledWith(pstream.publish, 'dtmf', {
-        callsid: conn.parameters.CallSid,
-        dtmf: '123',
-      });
+      sinon.assert.calledWith(pstream.dtmf, conn.parameters.CallSid, '123');
     });
 
     it('should emit error if pstream is disconnected', (done) => {
@@ -991,10 +988,9 @@ describe('Connection', function() {
               (conn as any)['_status'] = state;
             });
 
-            it('should call pstream.publish with hangup', () => {
+            it('should call pstream.hangup with error message', () => {
               mediaStream.onerror(Object.assign({ disconnect: true }, baseError));
-              sinon.assert.calledWith(pstream.publish, 'hangup');
-              assert.equal(pstream.publish.args[0][1].message, 'foo');
+              sinon.assert.calledWith(pstream.hangup, conn.outboundConnectionId, 'foo');
             });
 
             it('should call mediaStream.close', () => {
@@ -1013,9 +1009,9 @@ describe('Connection', function() {
               (conn as any)['_status'] = state;
             });
 
-            it('should not call pstream.publish', () => {
+            it('should not call pstream.hangup', () => {
               mediaStream.onerror(Object.assign({ disconnect: true }, baseError));
-              sinon.assert.notCalled(pstream.publish);
+              sinon.assert.notCalled(pstream.hangup);
             });
 
             it('should not call mediaStream.close', () => {
@@ -1225,9 +1221,9 @@ describe('Connection', function() {
           sinon.assert.calledWith(publisher.info, 'connection', 'disconnected-by-remote');
         });
 
-        it('should not call pstream.publish with hangup', () => {
+        it('should not call pstream.hangup', () => {
           pstream.emit('hangup', { callsid: 'CA123' });
-          sinon.assert.notCalled(pstream.publish);
+          sinon.assert.notCalled(pstream.hangup);
         });
 
         it('should throw an error if the payload contains an error', () => {
@@ -1266,9 +1262,9 @@ describe('Connection', function() {
           sinon.assert.notCalled(publisher.info);
         });
 
-        it('should not call pstream.publish with hangup', () => {
+        it('should not call pstream.hangup', () => {
           pstream.emit('hangup', { callsid: 'CA123' });
-          sinon.assert.notCalled(pstream.publish);
+          sinon.assert.notCalled(pstream.hangup);
         });
       });
     });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-4533](https://issues.corp.twilio.com/browse/CLIENT-4533)

### Description

This PR adds distinct PStream methods for each type of PStream/VSP message, so that all payload unit tests can reside in PStream. It also replaces all calls to `PStream.publish()` with the appropriate PStream methods.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [x] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
