### PR TITLE
CLIENT-7458 | Removing previously added insights error

### DIFF
--- a/PREFLIGHT.md
+++ b/PREFLIGHT.md
@@ -126,12 +126,6 @@ Raised when `PreflightTest.status` has transitioned to `completed`. During this 
   "samples": [...],
 
   /**
-   * Non-fatal errors detected during the test.
-   * These are coming from Device.on('error').
-   */
-  "errors": [...],
-
-  /**
    * Warnings detected during the test.
    * These are coming from Connection.on('warning').
    */
@@ -141,9 +135,6 @@ Raised when `PreflightTest.status` has transitioned to `completed`. During this 
 
 #### .on('connected', handler())
 Raised when `PreflightTest.status` has transitioned to `connected`. This means, the connection to Twilio has been established.
-
-#### .on('error', handler(error))
-Raised whenever the test encounters a non-fatal error. This is coming from [Device.on('error)](https://www.twilio.com/docs/voice/client/javascript/device#error) and uses the same error format.
 
 #### .on('failed', handler(error))
 Raised when `PreflightTest.status` has transitioned to `failed`. This happens when establishing a connection to Twilio has failed or when a test call has encountered a fatal error. This is also raised if `PreflightTest.stop` is called while the test is in progress. The error emitted from this event is coming from [Device.on('error)](https://www.twilio.com/docs/voice/client/javascript/device#error) and uses the same error format.

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -701,10 +701,6 @@ class Device extends EventEmitter {
 
     if (this.options.publishEvents === false) {
       this._publisher.disable();
-    } else {
-      this._publisher.on('error', (error: Error) => {
-        this._onPublisherError(error);
-      });
     }
 
     if (networkInformation) {
@@ -1003,31 +999,6 @@ class Device extends EventEmitter {
     if (!this.connections.length) {
       this.soundcache.get(Device.SoundName.Incoming).stop();
     }
-  }
-
-  /**
-   * Called when publisher raises an error event
-   * @param error
-   */
-  private _onPublisherError(publisherError: Error): void {
-    let info;
-    try {
-      const errorResponse = JSON.parse(publisherError.message);
-      info = {
-        code: errorResponse.code,
-        message: errorResponse.message,
-      };
-    } catch {
-      this._log.info('Unable to parse publisher error. The server might be down or unreachable.');
-    }
-
-    const twilioError = new ClientErrors.BadRequest();
-    this.emit('error', {
-      code: twilioError.code,
-      info,
-      message: 'Received an error while publishing events to insights',
-      twilioError,
-    });
   }
 
   /**

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -701,6 +701,10 @@ class Device extends EventEmitter {
 
     if (this.options.publishEvents === false) {
       this._publisher.disable();
+    } else {
+      this._publisher.on('error', (error: Error) => {
+        this._log.warn('Cannot connect to insights.', error);
+      });
     }
 
     if (networkInformation) {

--- a/tests/integration/preflight.ts
+++ b/tests/integration/preflight.ts
@@ -75,16 +75,6 @@ describe('Preflight Test', function() {
       assert.equal(preflight.status, PreflightTest.Status.Connecting);
     });
 
-    it('should emit non-fatal error', () => {
-      setTimeout(() => {
-        callerDevice.emit('error', { code: 31400 });
-      }, 5);
-
-      return waitFor(expectEvent('error', preflight).then(error => {
-        assert.deepEqual(error, { code: 31400 });
-      }), EVENT_TIMEOUT);
-    });
-
     it('should emit connected event', () => {
       return waitFor(expectEvent('connected', preflight).then(() => {
         callerConnection = preflight['_connection'];
@@ -119,7 +109,6 @@ describe('Preflight Test', function() {
       return waitFor(expectEvent('completed', preflight).then((report: PreflightTest.Report) => {
         assert(!!report);
         assert(!!report.samples.length);
-        assert(!!report.errors.length);
         assert(!!report.warnings.length);
         assert.deepEqual(report, preflight.report);
       }), EVENT_TIMEOUT);

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -564,41 +564,6 @@ describe('Device', function() {
       });
     });
 
-    describe('on Publisher.error', () => {
-      before(() => {
-        device.setup(token, Object.assign(setupOptions, { publishEvents: true }));
-      });
-
-      it('should emit a twilio error', (done) => {
-        device.on('error', error => {
-          assert.equal(error.code, 31400);
-          assert.equal(error.twilioError.code, 31400);
-          done();
-        });
-        publisher.emit('error', {});
-      });
-
-      it('should not populate info if message is not a valid json string', (done) => {
-        device.on('error', error => {
-          assert.equal(error.code, 31400);
-          assert.equal(error.twilioError.code, 31400);
-          assert(!error.info);
-          done();
-        });
-        publisher.emit('error', { message: 'foo' });
-      });
-
-      it('should populate info if message is a valid json string', (done) => {
-        device.on('error', error => {
-          assert.equal(error.code, 31400);
-          assert.equal(error.twilioError.code, 31400);
-          assert.deepStrictEqual(error.info, {code: 1, message: 'bar'});
-          done();
-        });
-        publisher.emit('error', { message: '{"code": 1, "message": "bar"}' });
-      });
-    });
-
     describe('createDefaultPayload', () => {
       xit('should be tested', () => {
         // This should be moved somewhere that it can be tested. This is currently:

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -163,31 +163,6 @@ describe('PreflightTest', () => {
     });
   });
 
-  describe('on error', () => {
-    it('should emit error for non fatal error', () => {
-      const onError = sinon.stub();
-      const preflight = new PreflightTest('foo', options);
-      preflight.on('error', onError);
-      device.emit('ready');
-
-      device.emit('error', { code: 31400 });
-
-      sinon.assert.calledOnce(onError);
-      sinon.assert.calledWithExactly(onError, { code: 31400 });
-    });
-
-    it('should not emit error for fatal errors', () => {
-      const onError = sinon.stub();
-      const preflight = new PreflightTest('foo', options);
-      preflight.on('error', onError);
-      device.emit('ready');
-
-      device.emit('error', { code: 123 });
-
-      sinon.assert.notCalled(onError);
-    });
-  });
-
   describe('on connected', () => {
     it('should emit connected', () => {
       const onConnected = sinon.stub();
@@ -250,7 +225,6 @@ describe('PreflightTest', () => {
         // This is derived from testSamples
         const expected = {
           callSid: CALL_SID,
-          errors: [{ code: 31400 }],
           networkTiming: {
             dtls: {
               duration: 1000,
@@ -301,11 +275,7 @@ describe('PreflightTest', () => {
       };
 
       preflight.on('completed', onCompleted);
-      preflight.on('error', sinon.stub());
       device.emit('ready');
-
-      // Populate error
-      device.emit('error', { code: 31400 });
 
       // Populate samples
       for (let i = 0; i < testSamples.length; i++) {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7458](https://issues.corp.twilio.com/browse/CLIENT-7458)

### Description

This PR removes the insights related error event per team's discussion. This also removes the error handler in the preflight test because Insights connection error is the only error event that preflight was catching.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
