### PR TITLE
CLIENT-7482 | Using async queue for async operations for sounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+1.10.1 (In Progress)
+===================
+
+Bug Fixes
+---------
+
+* Fixed an issue where `Device.on('incoming')` event is not raised when the incoming sound is stopped right after playing it. This is a timing issue which can happen if multiple incoming connections comes in almost at the same time. (CLIENT-7482, GH-129)
+
+
 1.10.0 (Feb 19, 2020)
 ===================
 

--- a/lib/twilio/asyncQueue.ts
+++ b/lib/twilio/asyncQueue.ts
@@ -1,0 +1,82 @@
+/**
+ * @module Voice
+ * @internalapi
+ */
+import Deferred from './deferred';
+
+/**
+ * Queue async operations and executes them synchronously.
+ */
+export class AsyncQueue {
+  /**
+   * The list of async operations in this queue
+   */
+  private _operations: AsyncQueue.Operation[] = [];
+
+  /**
+   * Adds the async operation to the queue
+   * @param callback An async callback that returns a promise
+   * @returns A promise that will get resolved or rejected after executing the callback
+   */
+  enqueue(callback: () => Promise<any>): Promise<any> {
+    const hasPending = !!this._operations.length;
+    const deferred = new Deferred();
+
+    this._operations.push({ deferred, callback });
+
+    if (!hasPending) {
+      this._processQueue();
+    }
+
+    return deferred.promise;
+  }
+
+  /**
+   * Start processing the queue. This executes the first item and removes it after.
+   * Then do the same for next items until the queue is emptied.
+   */
+  private async _processQueue() {
+    while (this._operations.length) {
+      // Grab first item, don't remove from array yet until it's resolved/rejected
+      const { deferred, callback } = this._operations[0];
+
+      // We want to capture the result/error first so we can remove the item from the queue later
+      let result;
+      let error;
+      // Sometimes result and error are empty. So let's use a separate flag to determine if the promise has resolved
+      let hasResolved;
+      try {
+        result = await callback();
+        hasResolved = true;
+      } catch (e) {
+        error = e;
+      }
+
+      // Remove the item
+      this._operations.shift();
+
+      if (hasResolved) {
+        deferred.resolve(result);
+      } else {
+        deferred.reject(error);
+      }
+    }
+  }
+}
+
+export namespace AsyncQueue {
+  /**
+   * Represent an [[AsyncQueue]] operation
+   */
+  export interface Operation {
+    /**
+     * An async callback that returns a promise. This will get called once it reaches the queue.
+     */
+    callback: () => Promise<any>;
+
+    /**
+     * A deferred promise that gets resolved or rejected after executing the async callback
+     */
+    deferred: Deferred;
+  }
+}

--- a/lib/twilio/sound.js
+++ b/lib/twilio/sound.js
@@ -1,3 +1,4 @@
+const AsyncQueue = require('./asyncQueue').AsyncQueue;
 const AudioPlayer = require('@twilio/audioplayer');
 const InvalidArgumentError = require('./errors').InvalidArgumentError;
 
@@ -53,6 +54,9 @@ function Sound(name, url, options) {
       value: null,
       writable: true
     },
+    _operations: {
+      value: new AsyncQueue()
+    },
     _playPromise: {
       value: null,
       writable: true
@@ -106,8 +110,8 @@ Sound.prototype._playAudioElement = function _playAudioElement(sinkId, isMuted, 
     throw new InvalidArgumentError(`sinkId: "${sinkId}" doesn't have an audio element`);
   }
 
-  audioElement.muted = isMuted;
-  audioElement.loop = shouldLoop;
+  audioElement.muted = !!isMuted;
+  audioElement.loop = !!shouldLoop;
 
   return audioElement.play()
     .then(() => audioElement)
@@ -124,11 +128,11 @@ Sound.prototype._playAudioElement = function _playAudioElement(sinkId, isMuted, 
  */
 Sound.prototype._play = function _play(forceIsMuted, forceShouldLoop) {
   if (this.isPlaying) {
-    this.stop();
+    this._stop();
   }
 
   if (this._maxDuration > 0) {
-    this._maxDurationTimeout = setTimeout(this.stop.bind(this), this._maxDuration);
+    this._maxDurationTimeout = setTimeout(this._stop.bind(this), this._maxDuration);
   }
 
   forceShouldLoop = typeof forceShouldLoop === 'boolean' ? forceShouldLoop : this._shouldLoop;
@@ -180,20 +184,9 @@ Sound.prototype._play = function _play(forceIsMuted, forceShouldLoop) {
 };
 
 /**
- * Update the sinkIds of the audio output devices this sound should play through.
- */
-Sound.prototype.setSinkIds = function setSinkIds(ids) {
-  if (!this._isSinkSupported) { return; }
-
-  ids = ids.forEach ? ids : [ids];
-  [].splice.apply(this._sinkIds, [0, this._sinkIds.length].concat(ids));
-};
-
-/**
  * Stop playing the sound.
- * @return {void}
  */
-Sound.prototype.stop = function stop() {
+Sound.prototype._stop = function _stop() {
   this._activeEls.forEach((audioEl, sinkId) => {
     if (this._sinkIds.includes(sinkId)) {
       audioEl.pause();
@@ -212,10 +205,30 @@ Sound.prototype.stop = function stop() {
 };
 
 /**
- * Start playing the sound.
+ * Update the sinkIds of the audio output devices this sound should play through.
+ */
+Sound.prototype.setSinkIds = function setSinkIds(ids) {
+  if (!this._isSinkSupported) { return; }
+
+  ids = ids.forEach ? ids : [ids];
+  [].splice.apply(this._sinkIds, [0, this._sinkIds.length].concat(ids));
+};
+
+/**
+ * Add a stop operation to the queue
+ */
+Sound.prototype.stop = function stop() {
+  this._operations.enqueue(() => {
+    this._stop();
+    return Promise.resolve();
+  });
+};
+
+/**
+ * Add a play operation to the queue
  */
 Sound.prototype.play = function play() {
-  this._play(false);
+  return this._operations.enqueue(() => this._play());
 };
 
 module.exports = Sound;

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -74,6 +74,7 @@ require('./pstream');
 require('./sound');
 require('./sdp');
 
+require('./unit/asyncQueue');
 require('./unit/candidate');
 require('./unit/connection');
 require('./unit/device');

--- a/tests/sound.js
+++ b/tests/sound.js
@@ -213,12 +213,37 @@ describe('Sound', () => {
 
     let context;
     let toTest;
+
+    beforeEach(() => {
+      context = {
+        _operations: {
+          enqueue: (cb) => cb()
+        },
+        _stop: sinon.stub(),
+      };
+      toTest = METHOD.bind(context);
+    });
+
+    it('should call _stop', () => {
+      toTest();
+      return wait().then(() => sinon.assert.calledOnce(context._stop));
+    });
+  });
+
+  context('Sound.prototype._stop', () => {
+    const METHOD = Sound.prototype._stop;
+
+    let context;
+    let toTest;
     let activeEls;
 
     beforeEach(() => {
       activeEls = new Map();
       context = {
         _activeEls: activeEls,
+        _operations: {
+          enqueue: (cb) => cb()
+        },
         _sinkIds: []
       };
       toTest = METHOD.bind(context);
@@ -275,7 +300,10 @@ describe('Sound', () => {
 
     beforeEach(() => {
       context = {
-        _play: sinon.stub()
+        _play: sinon.stub(),
+        _operations: {
+          enqueue: (cb) => cb()
+        },
       };
       toTest = METHOD.bind(context);
     });
@@ -283,16 +311,16 @@ describe('Sound', () => {
     it('should play unmuted', () => {
       toTest();
       sinon.assert.calledOnce(context._play);
-      sinon.assert.calledWithExactly(context._play, false);
+      assert(context._play.getCall(0).args.length === 0);
 
       toTest(true);
-      sinon.assert.calledWithExactly(context._play, false);
+      assert(context._play.getCall(0).args.length === 0);
     });
 
     it('should not override shouldLoop', () => {
       toTest(true, true);
       sinon.assert.calledOnce(context._play);
-      sinon.assert.calledWithExactly(context._play, false);
+      assert(context._play.getCall(0).args.length === 0);
     });
   });
 
@@ -312,7 +340,7 @@ describe('Sound', () => {
         _activeEls: activeEls,
         _sinkIds: [],
         _playAudioElement: sinon.stub(),
-        stop: sinon.stub()
+        _stop: sinon.stub(),
       };
 
       audio = new AudioFactory();
@@ -325,9 +353,9 @@ describe('Sound', () => {
     it('should call stop appropriately', () => {
       scope.isPlaying = true;
       toTest();
-      sinon.assert.calledOnce(scope.stop);
+      sinon.assert.calledOnce(scope._stop);
       sinon.assert.calledOnce(scope._playAudioElement);
-      sinon.assert.callOrder(scope.stop, scope._playAudioElement);
+      sinon.assert.callOrder(scope._stop, scope._playAudioElement);
     });
 
     it('should call stop after maxDuration threshold', () => {
@@ -335,7 +363,7 @@ describe('Sound', () => {
       scope._maxDuration = 10;
       toTest();
       return wait(20).then(() => {
-        sinon.assert.calledOnce(scope.stop);
+        sinon.assert.calledOnce(scope._stop);
       });
     });
 

--- a/tests/unit/asyncQueue.ts
+++ b/tests/unit/asyncQueue.ts
@@ -1,0 +1,114 @@
+import { AsyncQueue } from '../../lib/twilio/asyncQueue';
+import * as sinon from 'sinon';
+
+describe('AsyncQueue', () => {
+  let operations: AsyncQueue;
+  let stub1: any;
+  let stub2: any;
+  let stub3: any;
+
+  const wait = (timeout?: number) => new Promise(r => setTimeout(r, timeout || 0));
+
+  const getAsyncMethod = (delay: number, fail?: boolean): () => Promise<any> => {
+    return () => {
+      return new Promise((resolve, reject) => {
+        const callback = typeof fail === 'boolean' ? reject : resolve;
+        setTimeout(callback, delay);
+      });
+    };
+  };
+
+  beforeEach(() => {
+    operations = new AsyncQueue();
+
+    stub1 = sinon.stub();
+    stub2 = sinon.stub();
+    stub3 = sinon.stub();
+  });
+
+  context('adding items with similar async duration', () => {
+    it('should execute an operation when the queue is empty', () => {
+      operations.enqueue(getAsyncMethod(10)).then(stub1);
+      return wait(20).then(() => sinon.assert.calledOnce(stub1));
+    });
+
+    it('should fail an operation when the queue is empty', () => {
+      operations.enqueue(getAsyncMethod(10, true)).catch(stub1);
+      return wait(20).then(() => sinon.assert.calledOnce(stub1));
+    });
+
+    it('should execute an operation when the queue is not empty', () => {
+      operations.enqueue(getAsyncMethod(10)).then(stub1);
+      operations.enqueue(getAsyncMethod(10)).then(stub2);
+      operations.enqueue(getAsyncMethod(10)).then(stub3);
+      return wait(60).then(() => {
+        sinon.assert.calledOnce(stub1);
+        sinon.assert.calledOnce(stub2);
+        sinon.assert.calledOnce(stub3);
+        sinon.assert.callOrder(stub1, stub2, stub3);
+      });
+    });
+
+    it('should fail an operation when the queue is not empty', () => {
+      operations.enqueue(getAsyncMethod(10, true)).catch(stub1);
+      operations.enqueue(getAsyncMethod(10, true)).catch(stub2);
+      operations.enqueue(getAsyncMethod(10, true)).catch(stub3);
+      return wait(60).then(() => {
+        sinon.assert.calledOnce(stub1);
+        sinon.assert.calledOnce(stub2);
+        sinon.assert.calledOnce(stub3);
+        sinon.assert.callOrder(stub1, stub2, stub3);
+      });
+    });
+  });
+
+  context('adding items with different async duration', () => {
+    it('should execute an operation when the queue is not empty', () => {
+      operations.enqueue(getAsyncMethod(15)).then(stub1);
+      operations.enqueue(getAsyncMethod(10)).then(stub2);
+      operations.enqueue(getAsyncMethod(20)).then(stub3);
+      return wait(90).then(() => {
+        sinon.assert.calledOnce(stub1);
+        sinon.assert.calledOnce(stub2);
+        sinon.assert.calledOnce(stub3);
+        sinon.assert.callOrder(stub1, stub2, stub3);
+      });
+    });
+
+    it('should fail an operation when the queue is not empty', () => {
+      operations.enqueue(getAsyncMethod(15, true)).catch(stub1);
+      operations.enqueue(getAsyncMethod(10, true)).catch(stub2);
+      operations.enqueue(getAsyncMethod(25, true)).catch(stub3);
+      return wait(100).then(() => {
+        sinon.assert.calledOnce(stub1);
+        sinon.assert.calledOnce(stub2);
+        sinon.assert.calledOnce(stub3);
+        sinon.assert.callOrder(stub1, stub2, stub3);
+      });
+    });
+
+    it('should execute the correct order if first item is failing', () => {
+      operations.enqueue(getAsyncMethod(15, true)).catch(stub1);
+      operations.enqueue(getAsyncMethod(10)).then(stub2);
+      operations.enqueue(getAsyncMethod(10)).then(stub3);
+      return wait(70).then(() => {
+        sinon.assert.calledOnce(stub1);
+        sinon.assert.calledOnce(stub2);
+        sinon.assert.calledOnce(stub3);
+        sinon.assert.callOrder(stub1, stub2, stub3);
+      });
+    });
+
+    it('should execute the correct order if next item is failing', () => {
+      operations.enqueue(getAsyncMethod(15)).then(stub1);
+      operations.enqueue(getAsyncMethod(10, true)).catch(stub2);
+      operations.enqueue(getAsyncMethod(10, true)).catch(stub3);
+      return wait(70).then(() => {
+        sinon.assert.calledOnce(stub1);
+        sinon.assert.calledOnce(stub2);
+        sinon.assert.calledOnce(stub3);
+        sinon.assert.callOrder(stub1, stub2, stub3);
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7482](https://issues.corp.twilio.com/browse/CLIENT-7482)

### Description

Using async queue for async operations for sounds to fix the issue where error is thrown if play() and stop() are called subsequently.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
