### PR TITLE
CLIENT-7373 | [GH124] Android Chrome _updateAvailableDevices continuo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Bug Fixes
 ---------
 
 * Fixed an issue where `Device.on('incoming')` event is not raised when the incoming sound is stopped right after playing it. This is a timing issue which can happen if multiple incoming connections comes in almost at the same time. (CLIENT-7482, GH-129)
+* Fixed an issue where setting output devices on Android chrome throws the error `This browser does not support audio output selection`. We now check if this is supported on the browser before setting the output device. (CLIENT-7373, GH-124)
 
 
 1.10.0 (Feb 19, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Bug Fixes
 ---------
 
 * Fixed an issue where `Device.on('incoming')` event is not raised when the incoming sound is stopped right after playing it. This is a timing issue which can happen if multiple incoming connections comes in almost at the same time. (CLIENT-7482, GH-129)
-* Fixed an issue where setting output devices on Android chrome throws the error `This browser does not support audio output selection`. We now check if this is supported on the browser before setting the output device. (CLIENT-7373, GH-124)
+* Fixed an issue causing Android chrome to throw the error `This browser does not support audio output selection`. We now check if this is supported on the browser before attempting to update the output device. (CLIENT-7373, GH-124)
 
 
 1.10.0 (Feb 19, 2020)

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -515,8 +515,11 @@ class AudioHelper extends EventEmitter {
         || Array.from(this.availableOutputDevices.values())[0];
 
       [this.speakerDevices, this.ringtoneDevices].forEach(outputDevices => {
-        if (!outputDevices.get().size && this.availableOutputDevices.size) {
-          outputDevices.set(defaultDevice.deviceId);
+        if (!outputDevices.get().size && this.availableOutputDevices.size && this.isOutputSelectionSupported) {
+          outputDevices.set(defaultDevice.deviceId)
+            .catch((reason) => {
+              this._log.warn(`Unable to set audio output devices. ${reason}`);
+            });
         }
       });
     });

--- a/tests/audiohelper.js
+++ b/tests/audiohelper.js
@@ -480,7 +480,7 @@ describe('AudioHelper', () => {
       });
     });
 
-    describe('mediageDevices:deviceinfochange', () => {
+    describe('mediaDevices:deviceinfochange', () => {
       let audio;
       const wait = () => new Promise(r => setTimeout(r, 0));
       const noop = () => {};


### PR DESCRIPTION
…usly throws uncaught rejection

<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7373](https://issues.corp.twilio.com/browse/CLIENT-7373)

### Description

This PR changes _updateAvailableDevices such that we don't just throw it on the console if not supported.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
