### PR TITLE
[CLIENT-7519] Support for edge in Device.Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ New Features
 ---------
 
 * Deprecated the `Twilio.Device.Options.region` option for setting up a `Twilio.Device` as part of Phase 1 Regional Twilio.
-Instead of using `Twilio.Device.Options.region`, please use `Twilio.Device.Options.edge`. In the next breaking release, `Twilio.Device.Options.region` will no longer work as intended.
-Please see documentation TODO mhuynh.
+  Instead of using `Twilio.Device.Options.region`, please use `Twilio.Device.Options.edge`.
+  In the next breaking release, `Twilio.Device.Options.region` will no longer work as intended.
 
-The edge that the client connected to can be read from `Twilio.Device` using the getter-function `Twilio.Device.edge`.
+  Please see documentation TODO mhuynh.
+
+  The edge that the client connected to can be read from `Twilio.Device` using the getter-function `Twilio.Device.edge`.
 
 * Added `appName` and `appVersion` fields to Device.options. Pass these strings on Device setup, and they will be passed to Insights. This can
   be used to help debug which of your applications and/or versions an issue began occurring in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,35 @@ New Features
 
 * Deprecated the `Twilio.Device.Options.region` option for setting up a `Twilio.Device` as part of Phase 1 Regional Twilio.
 Instead of using `Twilio.Device.Options.region`, please use `Twilio.Device.Options.edge`. In a future breaking release, `Twilio.Device.Options.region` will be for a different option.
-Please see TODO mhuynh.
+
+Possible edges are detailed in `lib/regions.ts:Edge`.
+
+```ts
+enum Edge {
+  /**
+   * Public edges
+   */
+  Sydney = 'sydney',
+  SaoPaolo = 'sao-paolo',
+  Dublin = 'dublin',
+  Frankfurt = 'frankfurt',
+  Tokyo = 'tokyo',
+  Singapore = 'singapore',
+  Ashburn = 'ashburn',
+  Umatilla = 'umatilla',
+  Roaming = 'roaming',
+  /**
+   * Interconnect edges
+   */
+  AshburnIx = 'ashburn-ix',
+  SanJoseIx = 'san-jose-ix',
+  LondonIx = 'london-ix',
+  FrankfurtIx = 'frankfurt-ix',
+  SingaporeIx = 'singapore-ix',
+}
+```
+
+Please see documentation TODO mhuynh.
 
 Bug Fixes
 ---------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,19 @@
 New Features
 ---------
 
-* Deprecated the `Twilio.Device.Options.region` option for setting up a `Twilio.Device` as part of Phase 1 Regional Twilio.
-  Instead of using `Twilio.Device.Options.region`, please use `Twilio.Device.Options.edge`.
-  In the next breaking release, `Twilio.Device.Options.region` will no longer work as intended.
+* ### Twilio Regional
+  This release includes support for the first phase of the new **Twilio Regional**.
 
-  Please see documentation on [edges](https://www.twilio.com/docs/voice/voip-sdk/edges).
+  **Twilio Regional** brings the possibility to specify a home region where all data will reside and edge connectivity which the Voice SDKs will use to connect to the home region.
 
-  The edge that the client connected to can be read from `Twilio.Device` using the getter-function `Twilio.Device.edge`.
+  This first phase includes edge connectivity and the new parameter `Twilio.Device.Options.edge`.
+  This new parameter supersedes the now deprecated `Twilio.Device.Options.region`.
+  See `Twilio.Device.Options.edge` for migration instructions.
+  The edge that the client connected to can be read from `Twilio.Device` using the read-only property `Twilio.Device.edge`.
 
-* Added `appName` and `appVersion` fields to Device.options. Pass these strings on Device setup, and they will be passed to Insights. This can
+  Please see documentation on [edges](https://www.twilio.com/docs/voice/client/edges).
+
+* Added `appName` and `appVersion` fields to Device.options. Pass these strings on Device setup, and they will be passed to [Insights](https://www.twilio.com/console/voice/insights). This can
   be used to help debug which of your applications and/or versions an issue began occurring in.
   #### Example
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ New Features
   Instead of using `Twilio.Device.Options.region`, please use `Twilio.Device.Options.edge`.
   In the next breaking release, `Twilio.Device.Options.region` will no longer work as intended.
 
-  Please see documentation TODO mhuynh.
+  Please see documentation on [edges](https://www.twilio.com/docs/voice/voip-sdk/edges).
 
   The edge that the client connected to can be read from `Twilio.Device` using the getter-function `Twilio.Device.edge`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ New Features
 * ### Twilio Regional
   This release includes support for the first phase of the new **Twilio Regional**.
 
-  **Twilio Regional** brings the possibility to specify a home region where all data will reside and edge connectivity which the Voice SDKs will use to connect to the home region.
+  **Twilio Regional** allows developers to specify a region where data is processed and stored and specify an edge indicating where the SDK connects into Twilio.
 
   This first phase includes edge connectivity and the new parameter `Twilio.Device.Options.edge`.
   This new parameter supersedes the now deprecated `Twilio.Device.Options.region`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 1.11.0 (In Progress)
 ===================
 
+New Features
+---------
+
+* Deprecated the `Twilio.Device.Options.region` option for setting up a `Twilio.Device` as part of Phase 1 Regional Twilio.
+Instead of using `Twilio.Device.Options.region`, please use `Twilio.Device.Options.edge`. In a future breaking release, `Twilio.Device.Options.region` will be for a different option.
+Please see TODO mhuynh.
+
 Bug Fixes
 ---------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ New Features
 ---------
 
 * Deprecated the `Twilio.Device.Options.region` option for setting up a `Twilio.Device` as part of Phase 1 Regional Twilio.
-Instead of using `Twilio.Device.Options.region`, please use `Twilio.Device.Options.edge`. In a future breaking release, `Twilio.Device.Options.region` will be for a different option.
+Instead of using `Twilio.Device.Options.region`, please use `Twilio.Device.Options.edge`. In the next breaking release, `Twilio.Device.Options.region` will no longer work as intended.
 
 Possible edges are detailed in `lib/regions.ts:Edge`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,34 +6,6 @@ New Features
 
 * Deprecated the `Twilio.Device.Options.region` option for setting up a `Twilio.Device` as part of Phase 1 Regional Twilio.
 Instead of using `Twilio.Device.Options.region`, please use `Twilio.Device.Options.edge`. In the next breaking release, `Twilio.Device.Options.region` will no longer work as intended.
-
-Possible edges are detailed in `lib/regions.ts:Edge`.
-
-```ts
-enum Edge {
-  /**
-   * Public edges
-   */
-  Sydney = 'sydney',
-  SaoPaolo = 'sao-paolo',
-  Dublin = 'dublin',
-  Frankfurt = 'frankfurt',
-  Tokyo = 'tokyo',
-  Singapore = 'singapore',
-  Ashburn = 'ashburn',
-  Umatilla = 'umatilla',
-  Roaming = 'roaming',
-  /**
-   * Interconnect edges
-   */
-  AshburnIx = 'ashburn-ix',
-  SanJoseIx = 'san-jose-ix',
-  LondonIx = 'london-ix',
-  FrankfurtIx = 'frankfurt-ix',
-  SingaporeIx = 'singapore-ix',
-}
-```
-
 Please see documentation TODO mhuynh.
 
 Bug Fixes

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -500,7 +500,7 @@ class Device extends EventEmitter {
    * Get the {@link Edge} string the {@link Device} is currently connected to,
    * or 'offline' if not connected.
    */
-  edge(): string {
+  get edge(): string {
     this._throwUnlessSetup('edge');
     return typeof this._edge === 'string' ? this._edge : 'offline';
   }
@@ -860,7 +860,6 @@ class Device extends EventEmitter {
       aggressive_nomination: this.options.forceAggressiveIceNomination,
       browser_extension: this._isBrowserExtension,
       dscp: !!this.options.dscp,
-      edge: this.options.edge,
       ice_restart_enabled: this.options.enableIceRestart,
       platform: rtc.getMediaEngine(),
       sdk_version: C.RELEASE_VERSION,
@@ -882,19 +881,13 @@ class Device extends EventEmitter {
     setIfDefined('gateway', gateway);
 
     const region = this.stream && this.stream.region;
-
-    if (this.options.region) {
-      payload.selected_region = this.options.region;
-      setIfDefined('region', region);
-    }
-
-    if (this.options.edge) {
-      payload.selected_edge = this.options.edge;
-      setIfDefined(
-        'edge',
-        regionToEdge[region as Region] || region,
-      );
-    }
+    setIfDefined('selected_region', this.options.region);
+    setIfDefined('region', region);
+    setIfDefined('selected_edge', this.options.edge);
+    setIfDefined(
+      'edge',
+      regionToEdge[region as Region] || region,
+    );
 
     return payload;
   }

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -868,7 +868,7 @@ class Device extends EventEmitter {
       sdk_version: C.RELEASE_VERSION,
     };
 
-    function setIfDefined(propertyName: string, value: string | undefined) {
+    function setIfDefined(propertyName: string, value: string | undefined | null) {
       if (value) { payload[propertyName] = value; }
     }
 
@@ -880,17 +880,11 @@ class Device extends EventEmitter {
       payload.direction = connection.direction;
     }
 
-    const gateway = this.stream && this.stream.gateway;
-    setIfDefined('gateway', gateway);
-
-    const region = this.stream && this.stream.region;
+    setIfDefined('gateway', this.stream && this.stream.gateway);
     setIfDefined('selected_region', this.options.region);
-    setIfDefined('region', region);
+    setIfDefined('region', this.stream && this.stream.region);
     setIfDefined('selected_edge', this.options.edge);
-    setIfDefined(
-      'edge',
-      regionToEdge[region as Region] || region,
-    );
+    setIfDefined('edge', this._edge || this._region);
 
     return payload;
   }

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -551,7 +551,9 @@ class Device extends EventEmitter {
       'At the moment, it represents the region that the signaling stack ' +
       'connects to. ' +
       'In a future breaking release, this value will change meaning as part ' +
-      'of Twilio Regional.',
+      'of Twilio Regional.' +
+      '`Twilio.Device.edge` can alternatively be used to get the `edge` that ' +
+      'the device is connected to.',
     );
     this._throwUnlessSetup('region');
     return typeof this._region === 'string' ? this._region : 'offline';

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -19,9 +19,9 @@ import {
 import Log from './log';
 import { PStream } from './pstream';
 import {
-  defaultRegion,
+  defaultEdge,
+  getChunderURI,
   getRegionShortcode,
-  getRegionURI,
 } from './regions';
 import { Exception, queryToJson } from './util';
 
@@ -322,13 +322,13 @@ class Device extends EventEmitter {
     connectionFactory: Connection,
     debug: false,
     dscp: true,
+    edge: defaultEdge,
     enableIceRestart: false,
     eventgw: 'eventgw.twilio.com',
     forceAggressiveIceNomination: false,
     iceServers: [],
     noRegister: false,
     pStreamFactory: PStream,
-    region: defaultRegion,
     rtcConstraints: { },
     soundFactory: Sound,
     sounds: { },
@@ -580,6 +580,12 @@ class Device extends EventEmitter {
       throw new InvalidArgumentError('Token is required for Device.setup()');
     }
 
+    const regionURI = getChunderURI(
+      this.options.edge,
+      this.options.region,
+      this._log.warn,
+    );
+
     if (typeof Device._isUnifiedPlanDefault === 'undefined') {
       Device._isUnifiedPlanDefault = typeof window !== 'undefined'
         && typeof RTCPeerConnection !== 'undefined'
@@ -641,10 +647,6 @@ class Device extends EventEmitter {
         .forEach((eventName: Device.SoundName) => {
       this.sounds[eventName] = getOrSetSound.bind(null, eventName);
     });
-
-    const regionURI = getRegionURI(this.options.region, newRegion => this._log.warn(
-      `Region ${this.options.region} is deprecated, please use ${newRegion}.`,
-    ));
 
     this.options.chunderw = `wss://${this.options.chunderw || regionURI}/signal`;
 
@@ -1454,6 +1456,11 @@ namespace Device {
     dscp?: boolean;
 
     /**
+     * The edge to connect to.
+     */
+    edge?: string;
+
+    /**
      * Whether to automatically restart ICE when media connection fails
      */
     enableIceRestart?: boolean;
@@ -1489,6 +1496,10 @@ namespace Device {
 
     /**
      * The region code of the region to connect to.
+     *
+     * @deprecated
+     *
+     * CLIENT-7519 Deprecated in favor of the `edge` option parameter.
      */
     region?: string;
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -500,9 +500,12 @@ class Device extends EventEmitter {
    * Get the {@link Edge} string the {@link Device} is currently connected to,
    * or 'offline' if not connected.
    */
-  get edge(): string {
-    this._throwUnlessSetup('edge');
-    return typeof this._edge === 'string' ? this._edge : 'offline';
+  get edge(): string | null {
+    return this.isInitialized
+      ? typeof this._edge === 'string'
+        ? this._edge
+        : 'offline'
+      : null;
   }
 
   /**

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -274,7 +274,7 @@ class Device extends EventEmitter {
   private _connectionSinkIds: string[] = ['default'];
 
   /**
-   * The edge the {@link Device} is connected to.
+   * The name of the edge the {@link Device} is connected to.
    */
   private _edge: string | null = null;
 
@@ -497,15 +497,11 @@ class Device extends EventEmitter {
   }
 
   /**
-   * Get the {@link Edge} string the {@link Device} is currently connected to,
-   * or 'offline' if not connected.
+   * Returns the {@link Edge} value the {@link Device} is currently connected
+   * to. The value will be `null` when the {@link Device} is offline.
    */
   get edge(): string | null {
-    return this.isInitialized
-      ? typeof this._edge === 'string'
-        ? this._edge
-        : 'offline'
-      : null;
+    return this._edge;
   }
 
   /**
@@ -550,13 +546,8 @@ class Device extends EventEmitter {
    */
   region(): string {
     this._log.warn(
-      'The value that `Twilio.Device.region` returns is deprecated. ' +
-      'At the moment, it represents the region that the signaling stack ' +
-      'connects to. ' +
-      'In a future breaking release, this value will change meaning as part ' +
-      'of Twilio Regional.' +
-      '`Twilio.Device.edge` can alternatively be used to get the `edge` that ' +
-      'the device is connected to.',
+      '`Device.region` is deprecated and will be removed in the next major ' +
+      'release. Please use `Device.edge` instead.',
     );
     this._throwUnlessSetup('region');
     return typeof this._region === 'string' ? this._region : 'offline';
@@ -1510,7 +1501,8 @@ namespace Device {
      * will use to connect to Twilio infrastructure. The default value is
      * "roaming" which automatically selects an edge based on the latency of the
      * client relative to available edges. You may not specify both `edge` and
-     * `region` in the Device options.
+     * `region` in the Device options. Specifying both `edge` and `region` will
+     * result in an `InvalidArgumentException`.
      */
     edge?: string;
 
@@ -1556,6 +1548,29 @@ namespace Device {
      * CLIENT-7519 This parameter is deprecated in favor of the `edge`
      * parameter. You may not specify both `edge` and `region` in the Device
      * options.
+     *
+     * This parameter will be removed in the next major version release.
+     *
+     * The following table lists the new edge names to region name mappings.
+     * Instead of passing the `region` value in `options.region`, please pass the
+     * following `edge` value in `options.edge`.
+     *
+     * | Region Value | Edge Value   |
+     * |:-------------|:-------------|
+     * | au1          | sydney       |
+     * | br1          | sao-paolo    |
+     * | ie1          | dublin       |
+     * | de1          | frankfurt    |
+     * | jp1          | tokyo        |
+     * | sg1          | singapore    |
+     * | us1          | ashburn      |
+     * | us2          | umatilla     |
+     * | gll          | roaming      |
+     * | us1-ix       | ashburn-ix   |
+     * | us2-ix       | san-jose-ix  |
+     * | ie1-ix       | london-ix    |
+     * | de1-ix       | frankfurt-ix |
+     * | sg1-ix       | singapore-ix |
      */
     region?: string;
 

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -277,9 +277,9 @@ export function getChunderURI(
   } else if (region) {
     let chunderRegion = region;
 
-    // TODO mhuynh direct to documentation regarding Twilio regional phase 1
     deprecatedMessages.push(
-      'Regions are deprecated in favor of edges. Please see TODO.',
+      'Regions are deprecated in favor of edges. Please see this page for ' +
+      'documentation: https://www.twilio.com/docs/voice/voip-sdk/edges.',
     );
 
     const isDeprecatedRegion: boolean =

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -232,18 +232,11 @@ function createChunderRegionUri(region: string): string {
 }
 
 /**
- * The default chunder URI to connect to, should map to edge `roaming`.
- * @constant
- * @private
- */
-export const defaultChunderEdgeURI: string = 'voice.roaming.twilio.com';
-
-/**
  * String template for an edge chunder URI
  * @param edge - The edge.
  */
 function createChunderEdgeUri(edge: string): string {
-  return `voice.${edge}.twilio.com`;
+  return `voice-js.${edge}.twilio.com`;
 }
 
 /**

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -222,31 +222,6 @@ export const defaultEdge: Edge = Edge.Roaming;
 export const defaultChunderUri = 'chunderw-vpc-gll.twilio.com';
 
 /**
- * Get the URI associated with the passed shortcode.
- *
- * @private
- * @param region - The region shortcode. Defaults to gll.
- * @param [onDeprecated] - A callback containing the new region to be called when the passed region
- *   is deprecated.
- */
-export function getRegionURI(region?: string, onDeprecated?: (newRegion: string) => void): string {
-  if (region === undefined || region === defaultRegion) {
-    return `chunderw-vpc-gll.twilio.com`;
-  }
-
-  const newRegion = deprecatedRegions[region as DeprecatedRegion];
-  if (newRegion) {
-    region = newRegion;
-    if (onDeprecated) {
-      // Don't let this callback affect script execution.
-      setTimeout(() => onDeprecated(newRegion));
-    }
-  }
-
-  return `chunderw-vpc-gll-${region}.twilio.com`;
-}
-
-/**
  * Get the URI associated with the passed region or edge. If both are passed,
  * then we want to fail `Device` setup, so we throw an error.
  * As of CLIENT-7519, Regions are deprecated in favor of edges as part of

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -259,8 +259,8 @@ export function getRegionURI(region?: string, onDeprecated?: (newRegion: string)
  *   warned when the passed parameters are deprecated.
  */
 export function getChunderURI(
-  edge: any,
-  region: any,
+  edge: string | undefined,
+  region: string | undefined,
   onDeprecated?: (message: string) => void,
 ): string {
   if (

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -256,12 +256,15 @@ export function getChunderURI(
   region: string | undefined,
   onDeprecated?: (message: string) => void,
 ): string {
-  if (
-    (typeof region !== 'string' && typeof region !== 'undefined') ||
-    (typeof edge !== 'string' && typeof edge !== 'undefined')
-  ) {
+  if (typeof region !== 'string' && typeof region !== 'undefined') {
     throw new InvalidArgumentError(
-      'If `region` or `edge` are defined, they must of type `string`.',
+      'If `region` is defined, it must of type `string`.',
+    );
+  }
+
+  if (typeof edge !== 'string' && typeof edge !== 'undefined') {
+    throw new InvalidArgumentError(
+      'If `edge` is defined, it must of type `string`.',
     );
   }
 
@@ -271,15 +274,15 @@ export function getChunderURI(
 
   if (region && edge) {
     throw new InvalidArgumentError(
-      'Defining both a `region` and an `edge` in `Twilio.Device.Options` is ' +
-      'unsupported.',
+      'You cannot specify `region` when `edge` is specified in' +
+      '`Twilio.Device.Options`.',
     );
   } else if (region) {
     let chunderRegion = region;
 
     deprecatedMessages.push(
       'Regions are deprecated in favor of edges. Please see this page for ' +
-      'documentation: https://www.twilio.com/docs/voice/voip-sdk/edges.',
+      'documentation: https://www.twilio.com/docs/voice/client/edges.',
     );
 
     const isDeprecatedRegion: boolean =

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -3,7 +3,6 @@
  * This module describes valid and deprecated regions.
  */
 import { InvalidArgumentError } from './errors';
-import { Exception } from './util';
 
 /**
  * Valid deprecated regions.
@@ -21,12 +20,43 @@ export enum DeprecatedRegion {
 }
 
 /**
+ * Valid edges.
+ */
+export enum Edge {
+  Sydney = 'sydney',
+  SaoPaolo = 'sao-paolo',
+  Dublin = 'dublin',
+  Frankfurt = 'frankfurt',
+  Tokyo = 'tokyo',
+  Singapore = 'singapore',
+  Ashburn = 'ashburn',
+  Umatilla = 'umatilla',
+  Roaming = 'roaming',
+  /**
+   * Interconnect edges
+   */
+  AshburnIx = 'ashburn-ix',
+  SanJoseIx = 'san-jose-ix',
+  LondonIx = 'london-ix',
+  FrankfurtIx = 'frankfurt-ix',
+  SingaporeIx = 'singapore-ix',
+}
+
+/**
  * Valid current regions.
  *
- * @deprecated CLIENT-6831
+ * @deprecated
+ *
+ * CLIENT-6831
  * This is no longer used or updated for checking validity of regions in the
  * SDK. We now allow any string to be passed for region. Invalid regions won't
  * be able to connect, and won't throw an exception.
+ *
+ * CLIENT-7519
+ * This is used again to temporarily convert edge values to regions as part of
+ * Phase 1 Regional. This is still considered deprecated.
+ *
+ * @private
  */
 export enum Region {
   Au1 = 'au1',
@@ -39,6 +69,8 @@ export enum Region {
   Ie1Tnx = 'ie1-tnx',
   Jp1 = 'jp1',
   Sg1 = 'sg1',
+  Sg1Ix = 'sg1-ix',
+  Sg1Tnx = 'sg1-tnx',
   Us1 = 'us1',
   Us1Ix = 'us1-ix',
   Us1Tnx = 'us1-tnx',
@@ -55,6 +87,7 @@ export type ValidRegion = Region | DeprecatedRegion;
 
 /**
  * Deprecated regions. Maps the deprecated region to its equivalent up-to-date region.
+ * @private
  */
 export const deprecatedRegions: Record<DeprecatedRegion, Region> = {
   [DeprecatedRegion.Au]: Region.Au1,
@@ -96,6 +129,8 @@ const regionURIs: Record<Region, string> = {
   [Region.Ie1Tnx]: 'chunderw-vpc-gll-ie1-tnx.twilio.com',
   [Region.Jp1]: 'chunderw-vpc-gll-jp1.twilio.com',
   [Region.Sg1]: 'chunderw-vpc-gll-sg1.twilio.com',
+  [Region.Sg1Ix]: 'chunderw-vpc-gll-sg1-ix.twilio.com',
+  [Region.Sg1Tnx]: 'chunderw-vpc-gll-sg1-tnx.twilio.com',
   [Region.Us1]: 'chunderw-vpc-gll-us1.twilio.com',
   [Region.Us1Ix]: 'chunderw-vpc-gll-us1-ix.twilio.com',
   [Region.Us1Tnx]: 'chunderw-vpc-gll-us1-tnx.twilio.com',
@@ -105,11 +140,83 @@ const regionURIs: Record<Region, string> = {
 };
 
 /**
+ * Edge to region mapping, as part of Phase 1 Regional (CLIENT-7519).
+ * Temporary.
+ * @private
+ */
+export const edgeToRegion: Record<Edge, Region> = {
+  [Edge.Sydney]: Region.Au1,
+  [Edge.SaoPaolo]: Region.Br1,
+  [Edge.Dublin]: Region.Ie1,
+  [Edge.Frankfurt]: Region.De1,
+  [Edge.Tokyo]: Region.Jp1,
+  [Edge.Singapore]: Region.Sg1,
+  [Edge.Ashburn]: Region.Us1,
+  [Edge.Umatilla]: Region.Us2,
+  [Edge.Roaming]: Region.Gll,
+  /**
+   * Interconnect edges
+   */
+  [Edge.AshburnIx]: Region.Us1Ix,
+  [Edge.SanJoseIx]: Region.Us2Ix,
+  [Edge.LondonIx]: Region.Ie1Ix,
+  [Edge.FrankfurtIx]: Region.De1Ix,
+  [Edge.SingaporeIx]: Region.Sg1Ix,
+};
+
+/**
+ * Region to edge mapping, as part of Phase 1 Regional (CLIENT-7519).
+ * Temporary.
+ * @private
+ */
+export const regionToEdge: Record<Region, Edge> = {
+  [Region.Au1]: Edge.Sydney,
+  [Region.Br1]: Edge.SaoPaolo,
+  [Region.Ie1]: Edge.Dublin,
+  [Region.De1]: Edge.Frankfurt,
+  [Region.Jp1]: Edge.Tokyo,
+  [Region.Sg1]: Edge.Singapore,
+  [Region.Us1]: Edge.Ashburn,
+  [Region.Us2]: Edge.Umatilla,
+  [Region.Gll]: Edge.Roaming,
+  /**
+   * Interconnect edges
+   */
+  [Region.Us1Ix]: Edge.AshburnIx,
+  [Region.Us2Ix]: Edge.SanJoseIx,
+  [Region.Ie1Ix]: Edge.LondonIx,
+  [Region.De1Ix]: Edge.FrankfurtIx,
+  [Region.Sg1Ix]: Edge.SingaporeIx,
+  /**
+   * Tnx regions
+   */
+  [Region.Us1Tnx]: Edge.AshburnIx,
+  [Region.Us2Tnx]: Edge.AshburnIx,
+  [Region.Ie1Tnx]: Edge.LondonIx,
+  [Region.Sg1Tnx]: Edge.SingaporeIx,
+};
+
+/**
  * The default region to connect to and create a chunder uri from if region is
  * not defined.
  * @constant
+ * @private
  */
 export const defaultRegion: string = 'gll';
+
+/**
+ * The default edge to connect to and create a chunder uri from, if the edge
+ * parameter is not specified during setup in `Device`.
+ * @constant
+ */
+export const defaultEdge: Edge = Edge.Roaming;
+
+/**
+ * The default chunder URI to connect to, should map to `gll` or `roaming`.
+ * @constant
+ * @private
+ */
+export const defaultChunderUri = 'chunderw-vpc-gll.twilio.com';
 
 /**
  * Get the URI associated with the passed shortcode.
@@ -134,6 +241,86 @@ export function getRegionURI(region?: string, onDeprecated?: (newRegion: string)
   }
 
   return `chunderw-vpc-gll-${region}.twilio.com`;
+}
+
+/**
+ * Get the URI associated with the passed region or edge. If both are passed,
+ * then we want to fail `Device` setup, so we throw an error.
+ * As of CLIENT-7519, Regions are deprecated in favor of edges as part of
+ * Phase 1 Regional.
+ *
+ * @private
+ * @param edge - The edge.
+ * @param region - The region shortcode.
+ * @param [onDeprecated] - A callback containing the deprecation message to be
+ *   warned when the passed parameters are deprecated.
+ */
+export function getChunderURI(
+  edge: string | undefined,
+  region: string | undefined,
+  onDeprecated?: (message: string) => void,
+): string {
+  if (region && edge) {
+    throw new InvalidArgumentError(
+      'Defining both a `region` and an `edge` in `Twilio.Device.Options` is ' +
+      'unsupported.',
+    );
+  }
+
+  if ((edge === undefined || edge === defaultRegion) && region === undefined) {
+    return defaultChunderUri;
+  }
+
+  const deprecatedMessages: string[] = [];
+
+  let chunderRegion: string | undefined;
+
+  if (region) {
+    chunderRegion = region;
+
+    // TODO mhuynh direct to documentation regarding Twilio regional phase 1
+    deprecatedMessages.push(
+      'Regions are deprecated in favor of edges. Please see TODO.',
+    );
+
+    const isNonDeprecatedRegion: boolean =
+      (Object.values(Region) as string[]).includes(chunderRegion);
+
+    const isDeprecatedRegion: boolean =
+      (Object.values(DeprecatedRegion) as string[]).includes(chunderRegion);
+
+    if (isNonDeprecatedRegion || isDeprecatedRegion) {
+      chunderRegion =
+        deprecatedRegions[chunderRegion as DeprecatedRegion] || chunderRegion;
+
+      const preferredEdge = regionToEdge[chunderRegion as Region];
+      deprecatedMessages.push(
+        `Region "${chunderRegion}" is deprecated, please use \`edge\` ` +
+        `"${preferredEdge}".`,
+      );
+    }
+  }
+
+  if (edge) {
+    const isKnownEdge: boolean =
+      (Object.values(Edge) as string[]).includes(edge);
+
+    if (isKnownEdge) {
+      chunderRegion = edgeToRegion[edge as Edge];
+    } else {
+      chunderRegion = edge;
+    }
+  }
+
+  if (onDeprecated && deprecatedMessages.length) {
+    setTimeout(() => onDeprecated(deprecatedMessages.join(' ')));
+  }
+
+  if (chunderRegion === defaultRegion) {
+    return defaultChunderUri;
+  }
+
+  return `chunderw-vpc-gll-${chunderRegion}.twilio.com`;
 }
 
 /**

--- a/lib/twilio/wstransport.ts
+++ b/lib/twilio/wstransport.ts
@@ -291,8 +291,8 @@ export default class WSTransport extends EventEmitter {
         message: event.reason ||
           'Websocket connection to Twilio\'s signaling servers were ' +
           'unexpectedly ended. If this is happening consistently, there may ' +
-          'be an issue resolving the hostname provided. If a region is being ' +
-          'specified in Device setup, ensure it\'s a valid region.',
+          'be an issue resolving the hostname provided. If a region or an ' +
+          'edge is being specified in Device setup, ensure it is valid.',
         twilioError: new SignalingErrors.ConnectionError(),
       });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-client",
-  "version": "1.10.2-dev",
+  "version": "1.11.0-dev",
   "description": "Javascript SDK for Twilio Client",
   "main": "./es5/twilio.js",
   "types": "./es5/twilio.d.ts",

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -227,6 +227,11 @@ describe('Device', function() {
           assert.throws(() => (device.setup as any)(), /Token is required/);
         });
 
+        it('should throw if both `edge` and `region` are defined in options', () => {
+          device = new Device();
+          assert.throws(() => device.setup(token, { edge: 'foo', region: 'bar' }));
+        });
+
         it('should set device.isInitialized to true', () => {
           assert.equal(device.isInitialized, true);
         });

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -425,9 +425,9 @@ describe('Device', function() {
       });
     });
 
-    describe('.edge()', () => {
+    describe('.edge', () => {
       it(`should return 'offline' if not connected`, () => {
-        assert.equal(device.edge(), 'offline');
+        assert.equal(device.edge, 'offline');
       });
 
       // these unit tests will need to be changed for Phase 2 Regional
@@ -436,7 +436,7 @@ describe('Device', function() {
           const preferredEdge = regionToEdge[region as Region];
           it(`should return ${preferredEdge} for ${region}`, () => {
             pstream.emit('connected', { region: fullName });
-            assert.equal(device.edge(), preferredEdge);
+            assert.equal(device.edge, preferredEdge);
           });
         });
       });

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -426,8 +426,8 @@ describe('Device', function() {
     });
 
     describe('.edge', () => {
-      it(`should return 'offline' if not connected`, () => {
-        assert.equal(device.edge, 'offline');
+      it(`should return 'null' if not connected`, () => {
+        assert.equal(device.edge, null);
       });
 
       // these unit tests will need to be changed for Phase 2 Regional

--- a/tests/unit/regions.ts
+++ b/tests/unit/regions.ts
@@ -7,47 +7,12 @@ import {
   edgeToRegion,
   getChunderURI,
   getRegionShortcode,
-  getRegionURI,
   Region,
   regionShortcodes,
   regionToEdge,
 } from '../../lib/twilio/regions';
 
 describe('regions', () => {
-  describe('getRegionURI', () => {
-    (Object as any).entries(deprecatedRegions).forEach(([deprecatedRegion, newRegion]: [string, string]) => {
-      it(`should note ${deprecatedRegion} as deprecated and recommend ${newRegion}`, async () => {
-        const uri = getRegionURI(deprecatedRegion);
-        const region = await new Promise(async resolveRegion => {
-          getRegionURI(deprecatedRegion, resolveRegion);
-        });
-
-        assert.equal(`chunderw-vpc-gll-${newRegion}.twilio.com`, uri);
-        assert.equal(newRegion, region);
-      });
-    });
-
-    it('should not call `onDeprecated` for a non-deprecated region', () => {
-      const region = 'some_region';
-      let called = false;
-      const uri = getRegionURI(region, () => called = true);
-
-      assert.equal(`chunderw-vpc-gll-${region}.twilio.com`, uri);
-      assert(!called);
-    });
-
-    describe('should return the default chunderw uri', () => {
-      it('when region is `undefined`', () => {
-        const region = undefined;
-        assert.equal(`chunderw-vpc-gll.twilio.com`, getRegionURI(region));
-      });
-      it('when region is `gll`', () => {
-        const region = 'gll';
-        assert.equal(`chunderw-vpc-gll.twilio.com`, getRegionURI(region));
-      });
-    });
-  });
-
   describe('getChunderURI', () => {
     let onDeprecated: sinon.SinonSpy;
 

--- a/tests/unit/regions.ts
+++ b/tests/unit/regions.ts
@@ -170,7 +170,7 @@ describe('regions', () => {
 
         it('should transform the uri properly', () => {
           const uri = getChunderURI('foo', undefined, onDeprecated);
-          assert.equal(uri, 'voice.foo.twilio.com');
+          assert.equal(uri, 'voice-js.foo.twilio.com');
         });
       });
 

--- a/tests/unit/regions.ts
+++ b/tests/unit/regions.ts
@@ -20,6 +20,22 @@ describe('regions', () => {
       onDeprecated = sinon.spy();
     });
 
+    describe('with invalid parameter typings', async () => {
+      [
+        [null, undefined],
+        [undefined, null],
+        [null, null],
+      ].forEach(([edge, region]) => {
+        describe(`edge "${edge}" and region "${region}"`, () => {
+          it('should throw', () => {
+            assert.throws(() => {
+              getChunderURI(edge as any, region as any);
+            });
+          });
+        });
+      });
+    });
+
     it('should work with or without the deprecation handler', async () => {
       const uri = [
         getChunderURI(undefined, undefined, onDeprecated),
@@ -154,7 +170,7 @@ describe('regions', () => {
 
         it('should transform the uri properly', () => {
           const uri = getChunderURI('foo', undefined, onDeprecated);
-          assert.equal(uri, 'chunderw-vpc-gll-foo.twilio.com');
+          assert.equal(uri, 'voice.foo.twilio.com');
         });
       });
 

--- a/tests/unit/regions.ts
+++ b/tests/unit/regions.ts
@@ -109,7 +109,7 @@ describe('regions', () => {
           getChunderURI(undefined, 'foo', onDeprecated);
           await new Promise(resolve => setTimeout(() => {
             assert(onDeprecated.calledOnce);
-            assert.equal(onDeprecated.args[0][0].match(new RegExp('edge', 'g')).length, 1);
+            assert.equal(onDeprecated.args[0][0].match(new RegExp('edge', 'g')).length, 2);
             assert.equal(onDeprecated.args[0][0].match(new RegExp('please use', 'g')), null);
             resolve();
           }));
@@ -126,7 +126,7 @@ describe('regions', () => {
           getChunderURI(undefined, 'gll', onDeprecated);
           await new Promise(resolve => setTimeout(() => {
             assert(onDeprecated.calledOnce);
-            assert.equal(onDeprecated.args[0][0].match(new RegExp('edge', 'g')).length, 2);
+            assert.equal(onDeprecated.args[0][0].match(new RegExp('edge', 'g')).length, 3);
             assert.equal(onDeprecated.args[0][0].match(new RegExp(`please use \`edge\` "roaming"`, 'g')).length, 1);
             resolve();
           }));

--- a/tests/unit/regions.ts
+++ b/tests/unit/regions.ts
@@ -1,5 +1,17 @@
-import { getRegionURI, deprecatedRegions } from '../../lib/twilio/regions';
 import * as assert from 'assert';
+import * as sinon from 'sinon';
+import {
+  defaultEdge,
+  defaultRegion,
+  deprecatedRegions,
+  edgeToRegion,
+  getChunderURI,
+  getRegionShortcode,
+  getRegionURI,
+  Region,
+  regionShortcodes,
+  regionToEdge,
+} from '../../lib/twilio/regions';
 
 describe('regions', () => {
   describe('getRegionURI', () => {
@@ -33,6 +45,186 @@ describe('regions', () => {
         const region = 'gll';
         assert.equal(`chunderw-vpc-gll.twilio.com`, getRegionURI(region));
       });
+    });
+  });
+
+  describe('getChunderURI', () => {
+    let onDeprecated: sinon.SinonSpy;
+
+    beforeEach(() => {
+      onDeprecated = sinon.spy();
+    });
+
+    it('should work with or without the deprecation handler', async () => {
+      const uri = [
+        getChunderURI(undefined, undefined, onDeprecated),
+        getChunderURI(undefined, undefined),
+      ];
+      assert.equal(uri[0], uri[1]);
+      assert.equal(uri[0], 'chunderw-vpc-gll.twilio.com');
+    });
+
+    describe('without edge or region', () => {
+      it('should not call the deprecation handler', async () => {
+        getChunderURI(undefined, undefined, onDeprecated);
+        await new Promise(resolve => setTimeout(() => {
+          assert.equal(onDeprecated.callCount, 0);
+          resolve();
+        }));
+      });
+
+      it('should return the default chunder uri', () => {
+        const uri = getChunderURI(undefined, undefined);
+        assert.equal(uri, 'chunderw-vpc-gll.twilio.com');
+      });
+    });
+
+    describe('without edge and with region', () => {
+      describe('for deprecated known regions', () => {
+        Object.entries(deprecatedRegions).forEach(([deprecatedRegion, preferredRegion]) => {
+          describe(deprecatedRegion, () => {
+            it('should call the deprecation handler and recommend an edge', async () => {
+              const preferredEdge = regionToEdge[preferredRegion];
+              getChunderURI(undefined, deprecatedRegion, onDeprecated);
+
+              await new Promise(resolve => setTimeout(() => {
+                assert(onDeprecated.calledOnce);
+                assert(onDeprecated.args[0][0].match(new RegExp(`please use \`edge\` "${preferredEdge}"`)));
+                resolve();
+              }));
+            });
+
+            it('should return the right chunder uri', () => {
+              const uri = getChunderURI(undefined, deprecatedRegion, onDeprecated);
+              assert.equal(uri, `chunderw-vpc-gll-${preferredRegion}.twilio.com`);
+            });
+          });
+        });
+      });
+
+      describe('for nondeprecated known regions', () => {
+        Object.values(Region).filter(r => r !== defaultRegion).forEach(region => {
+          describe(region, () => {
+            it('should call the deprecation handler and recommend an edge', async () => {
+              const preferredEdge = regionToEdge[region];
+              getChunderURI(undefined, region, onDeprecated);
+              await new Promise(resolve => setTimeout(() => {
+                assert(onDeprecated.calledOnce);
+                assert(onDeprecated.args[0][0].match(new RegExp(`please use \`edge\` "${preferredEdge}"`)));
+                resolve();
+              }));
+            });
+
+            it('should return the right chunder uri', () => {
+              const uri = getChunderURI(undefined, region, onDeprecated);
+              assert.equal(uri, `chunderw-vpc-gll-${region}.twilio.com`);
+            });
+          });
+        });
+      });
+
+      describe('for an unknown region', () => {
+        it('should call the deprecation handler, but not recommend an edge', async () => {
+          getChunderURI(undefined, 'foo', onDeprecated);
+          await new Promise(resolve => setTimeout(() => {
+            assert(onDeprecated.calledOnce);
+            assert.equal(onDeprecated.args[0][0].match(new RegExp('edge', 'g')).length, 1);
+            assert.equal(onDeprecated.args[0][0].match(new RegExp('please use', 'g')), null);
+            resolve();
+          }));
+        });
+
+        it('should return the right chunder uri', () => {
+          const uri = getChunderURI(undefined, 'foo', onDeprecated);
+          assert.equal(uri, 'chunderw-vpc-gll-foo.twilio.com');
+        });
+      });
+
+      describe('for the default (gll) region', () => {
+        it('should call the deprecation handler and recommend an edge', async () => {
+          getChunderURI(undefined, 'gll', onDeprecated);
+          await new Promise(resolve => setTimeout(() => {
+            assert(onDeprecated.calledOnce);
+            assert.equal(onDeprecated.args[0][0].match(new RegExp('edge', 'g')).length, 2);
+            assert.equal(onDeprecated.args[0][0].match(new RegExp(`please use \`edge\` "roaming"`, 'g')).length, 1);
+            resolve();
+          }));
+        });
+
+        it('should return the right chunder uri', () => {
+          const uri = getChunderURI(undefined, 'gll', onDeprecated);
+          assert.equal(uri, 'chunderw-vpc-gll.twilio.com');
+        });
+      });
+    });
+
+    describe('with edge and without region', () => {
+      describe('for known edges', () => {
+        Object.entries(edgeToRegion).filter(([e]) => e !== defaultEdge).forEach(([edge, region]) => {
+          describe(edge, () => {
+            it('should not call the deprecation handler', async () => {
+              getChunderURI(edge, undefined, onDeprecated);
+              await new Promise(resolve => setTimeout(() => {
+                assert(onDeprecated.notCalled);
+                resolve();
+              }));
+            });
+
+            it('should return the right chunder uri', () => {
+              const uri = getChunderURI(edge, undefined, onDeprecated);
+              assert.equal(uri, `chunderw-vpc-gll-${region}.twilio.com`);
+            });
+          });
+        });
+      });
+
+      describe('for unknown edges', () => {
+        it('should not call the deprecation handler', async () => {
+          getChunderURI('foo', undefined, onDeprecated);
+          await new Promise(resolve => setTimeout(() => {
+            assert(onDeprecated.notCalled);
+            resolve();
+          }));
+        });
+
+        it('should transform the uri properly', () => {
+          const uri = getChunderURI('foo', undefined, onDeprecated);
+          assert.equal(uri, 'chunderw-vpc-gll-foo.twilio.com');
+        });
+      });
+
+      describe('for default (roaming) edge', () => {
+        it('should not call the deprecation handler', async () => {
+          getChunderURI('roaming', undefined, onDeprecated);
+          await new Promise(resolve => setTimeout(() => {
+            assert(onDeprecated.notCalled);
+            resolve();
+          }));
+        });
+
+        it('should transform the uri properly', () => {
+          const uri = getChunderURI('roaming', undefined, onDeprecated);
+          assert.equal(uri, 'chunderw-vpc-gll.twilio.com');
+        });
+      });
+    });
+
+    it('should throw an error with both', () => {
+      assert.throws(() => getChunderURI('foo', 'bar', onDeprecated));
+    });
+  });
+
+  describe('getRegionShortcode', () => {
+    it('should return the correct region from the shortcode', () => {
+      Object.entries(regionShortcodes).forEach(([shortcode, region]) => {
+        const result = getRegionShortcode(shortcode);
+        assert.equal(result, region);
+      });
+    });
+
+    it('should return null for an unknown shortcode', () => {
+      const result = getRegionShortcode('foo');
+      assert.equal(result, null);
     });
   });
 });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7519](https://issues.corp.twilio.com/browse/CLIENT-7519)

### Description

This PR is a work in progress and should not be merged to `master` yet. It exists for discussion and iteration.

#### TODO
- [x] Check the deprecation warnings and link to docs regarding edge and region changes
- [x] Check the changelog message and link to docs
- [ ] Ensure the generated TSDoc is up-to-date

Add `edge` parameter to `Twilio.Device.Options`, map new edge strings to existing region strings, and add deprecation warnings if `Twilio.Device.Options.region` is used.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
