### PR TITLE
[CLIENT-7483] Implement region in Preflight Test.

### DIFF
--- a/PREFLIGHT.md
+++ b/PREFLIGHT.md
@@ -127,7 +127,7 @@ Raised when `PreflightTest.status` has transitioned to `completed`. During this 
   "samples": [...],
 
   /**
-   * The region passed to `Device.preflightTest`.
+   * The region passed to `Device.testPreflight`.
    */
   "selectedRegion": "gll",
 

--- a/PREFLIGHT.md
+++ b/PREFLIGHT.md
@@ -19,6 +19,7 @@ The `options` parameter is a JavaScript object containing configuration settings
 |:---------|:--------|:------------|
 | `codecPreferences` | `['pcmu', 'opus']` | An ordered list of preferred codecs. |
 | `debug` | `false` | Can be `true` or `false`. Set this property to true to enable debug logging in your browser console. |
+| `region` | `gll` | Specifies which Twilio Data Center to use when initiating the test call. Please see this [page](https://www.twilio.com/docs/voice/client/regions#twilio-js-regions) for the list of available regions. |
 
 Events
 ------
@@ -126,14 +127,14 @@ Raised when `PreflightTest.status` has transitioned to `completed`. During this 
   "samples": [...],
 
   /**
-   * The region passed to the `Twilio.Device`.
+   * The region passed to `Device.preflightTest`.
    */
-  "selectedRegion": "foobar",
+  "selectedRegion": "gll",
 
   /**
-   * The region that the `Twilio.Device` actually connected to.
+   * The region that the test call was connected to.
    */
-  "region": "biffbazz",
+  "region": "us1",
 
   /**
    * Warnings detected during the test.

--- a/PREFLIGHT.md
+++ b/PREFLIGHT.md
@@ -33,7 +33,7 @@ Raised when `PreflightTest.status` has transitioned to `completed`. During this 
   "callSid": "CAa6a7a187a9cba2714d6fdccf472cc7b1",
 
   /**
-   * Network related time measurements which includes millisecond timestamps 
+   * Network related time measurements which includes millisecond timestamps
    * and duration for each type of connection.
    */
   "networkTiming": {
@@ -124,6 +124,16 @@ Raised when `PreflightTest.status` has transitioned to `completed`. During this 
    * https://www.twilio.com/docs/voice/client/javascript/connection#sample
    */
   "samples": [...],
+
+  /**
+   * The region passed to the `Twilio.Device`.
+   */
+  "selectedRegion": "foobar",
+
+  /**
+   * The region that the `Twilio.Device` actually connected to.
+   */
+  "region": "biffbazz",
 
   /**
    * Warnings detected during the test.

--- a/PREFLIGHT.md
+++ b/PREFLIGHT.md
@@ -127,14 +127,14 @@ Raised when `PreflightTest.status` has transitioned to `completed`. During this 
   "samples": [...],
 
   /**
-   * The region passed to `Device.testPreflight`.
+   * The edge passed to `Device.testPreflight`.
    */
-  "selectedRegion": "gll",
+  "selectedEdge": "roaming",
 
   /**
-   * The region that the test call was connected to.
+   * The edge that the test call was connected to.
    */
-  "region": "us1",
+  "edge": "ashburn",
 
   /**
    * Warnings detected during the test.

--- a/PREFLIGHT.md
+++ b/PREFLIGHT.md
@@ -19,7 +19,7 @@ The `options` parameter is a JavaScript object containing configuration settings
 |:---------|:--------|:------------|
 | `codecPreferences` | `['pcmu', 'opus']` | An ordered list of preferred codecs. |
 | `debug` | `false` | Can be `true` or `false`. Set this property to true to enable debug logging in your browser console. |
-| `region` | `gll` | Specifies which Twilio Data Center to use when initiating the test call. Please see this [page](https://www.twilio.com/docs/voice/client/regions#twilio-js-regions) for the list of available regions. |
+| `edge` | `roaming` | Specifies which Twilio `edge` to use when initiating the test call. Please see documentation on [edges](https://www.twilio.com/docs/voice/client/edges). |
 
 Events
 ------

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -186,7 +186,9 @@ export class PreflightTest extends EventEmitter {
     return {
       callSid: this._callSid,
       networkTiming: this._networkTiming,
+      region: this._device.region(),
       samples: this._samples,
+      selectedRegion: 'gll',
       stats: this._getRTCStats(),
       testTiming,
       totals: this._getRTCSampleTotals(),
@@ -537,9 +539,20 @@ export namespace PreflightTest {
     networkTiming: NetworkTiming;
 
     /**
+     * The region that we end up connecting to in the signaling stack.
+     * Parsed from the `connected` event that occurs upon connection.
+     */
+    region: string;
+
+    /**
      * WebRTC samples collected during the test.
      */
     samples: RTCSample[];
+
+    /**
+     * The region provided in the {@link PreflightTest.Options}.
+     */
+    selectedRegion: string;
 
     /**
      * RTC related stats captured during the test.

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -565,7 +565,7 @@ export namespace PreflightTest {
     samples: RTCSample[];
 
     /**
-     * The region passed to `Device.preflightTest`.
+     * The region passed to `Device.testPreflight`.
      */
     selectedRegion?: string;
 

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -477,7 +477,10 @@ export namespace PreflightTest {
     debug?: boolean;
 
     /**
-     * The region to connect the test call through.
+     * Specifies which Twilio Data Center to use when initiating the test call.
+     * Please see this
+     * [page](https://www.twilio.com/docs/voice/client/regions#twilio-js-regions)
+     * for the list of available regions.
      */
     region?: string;
   }
@@ -552,8 +555,7 @@ export namespace PreflightTest {
     networkTiming: NetworkTiming;
 
     /**
-     * The region that we end up connecting to in the signaling stack.
-     * Parsed from the `connected` event that occurs upon connection.
+     * The region that the test call was connected to.
      */
     region?: string;
 
@@ -563,7 +565,7 @@ export namespace PreflightTest {
     samples: RTCSample[];
 
     /**
-     * The region provided to the {@link Device} created for the test call.
+     * The region passed to `Device.preflightTest`.
      */
     selectedRegion?: string;
 

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -261,7 +261,7 @@ export class PreflightTest extends EventEmitter {
   private _onDeviceReady(): void {
     this._connection = this._device.connect();
     this._setupConnectionHandlers(this._connection);
-    this._edge = this._device.edge();
+    this._edge = this._device.edge || undefined;
 
     this._device.once('disconnect', () => {
       this._device.once('offline', () => this._onCompleted());

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -479,7 +479,7 @@ export namespace PreflightTest {
     /**
      * Specifies which Twilio Data Center to use when initiating the test call.
      * Please see this
-     * [page](TODO)
+     * [page](https://www.twilio.com/docs/voice/client/edges)
      * for the list of available edges.
      */
     edge?: string;

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -501,7 +501,7 @@ export namespace PreflightTest {
      * for the list of available edges.
      */
     edge?: string;
-    
+
     /**
      * Amount of time to wait for setting up signaling connection.
      * @default 10000

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -78,6 +78,11 @@ export class PreflightTest extends EventEmitter {
   private _device: Device;
 
   /**
+   * The edge that the `Twilio.Device` connected to.
+   */
+  private _edge: string | undefined;
+
+  /**
    * End of test timestamp
    */
   private _endTime: number | undefined;
@@ -98,13 +103,8 @@ export class PreflightTest extends EventEmitter {
   private _options: PreflightTest.Options = {
     codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
     debug: false,
-    region: 'gll',
+    edge: 'roaming',
   };
-
-  /**
-   * The region that the `Twilio.Device` connected to.
-   */
-  private _region: string | undefined;
 
   /**
    * The report for this test.
@@ -150,7 +150,7 @@ export class PreflightTest extends EventEmitter {
       this._device = new (options.deviceFactory || Device)(token, {
         codecPreferences: this._options.codecPreferences,
         debug: this._options.debug,
-        region: this._options.region,
+        edge: this._options.edge,
       });
     } catch (error) {
       // We want to return before failing so the consumer can capture the event
@@ -192,10 +192,10 @@ export class PreflightTest extends EventEmitter {
     }
     return {
       callSid: this._callSid,
+      edge: this._edge,
       networkTiming: this._networkTiming,
-      region: this._region,
       samples: this._samples,
-      selectedRegion: this._options.region,
+      selectedEdge: this._options.edge,
       stats: this._getRTCStats(),
       testTiming,
       totals: this._getRTCSampleTotals(),
@@ -261,7 +261,7 @@ export class PreflightTest extends EventEmitter {
   private _onDeviceReady(): void {
     this._connection = this._device.connect();
     this._setupConnectionHandlers(this._connection);
-    this._region = this._device.region();
+    this._edge = this._device.edge();
 
     this._device.once('disconnect', () => {
       this._device.once('offline', () => this._onCompleted());
@@ -479,10 +479,10 @@ export namespace PreflightTest {
     /**
      * Specifies which Twilio Data Center to use when initiating the test call.
      * Please see this
-     * [page](https://www.twilio.com/docs/voice/client/regions#twilio-js-regions)
-     * for the list of available regions.
+     * [page](TODO)
+     * for the list of available edges.
      */
-    region?: string;
+    edge?: string;
   }
 
   /**
@@ -550,14 +550,14 @@ export namespace PreflightTest {
     callSid: string | undefined;
 
     /**
+     * The edge that the test call was connected to.
+     */
+    edge?: string;
+
+    /**
      * Network related time measurements.
      */
     networkTiming: NetworkTiming;
-
-    /**
-     * The region that the test call was connected to.
-     */
-    region?: string;
 
     /**
      * WebRTC samples collected during the test.
@@ -565,9 +565,9 @@ export namespace PreflightTest {
     samples: RTCSample[];
 
     /**
-     * The region passed to `Device.testPreflight`.
+     * The edge passed to `Device.testPreflight`.
      */
-    selectedRegion?: string;
+    selectedEdge?: string;
 
     /**
      * RTC related stats captured during the test.

--- a/tests/integration/preflight.ts
+++ b/tests/integration/preflight.ts
@@ -145,13 +145,13 @@ describe('Preflight Test', function() {
     });
   });
 
-  describe('when using non-default region options', () => {
+  describe('when using non-default edge options', () => {
     [
-      ['gll', 'us1'],
-      ['us1', 'us1'],
-      ['ie1', 'ie1'],
-    ].forEach(([selectedRegion, region]) => {
-      describe(selectedRegion, () => {
+      ['roaming', 'ashburn'],
+      ['ashburn', 'ashburn'],
+      ['dublin', 'dublin'],
+    ].forEach(([selectedEdge, edge]) => {
+      describe(selectedEdge, () => {
         let report: PreflightTest.Report | undefined;
 
         before(async () => {
@@ -160,7 +160,7 @@ describe('Preflight Test', function() {
             conn.accept();
           });
           preflight = Device.testPreflight(callerToken, {
-            region: selectedRegion,
+            edge: selectedEdge,
           });
           const waitForReport: Promise<PreflightTest.Report> =
             new Promise(resolve => {
@@ -182,8 +182,8 @@ describe('Preflight Test', function() {
         });
 
         it('should use region passed in', () => {
-          assert.equal(report?.selectedRegion, selectedRegion);
-          assert.equal(report?.region, region);
+          assert.equal(report?.selectedEdge, selectedEdge);
+          assert.equal(report?.edge, edge);
         });
       });
     });

--- a/tests/integration/preflight.ts
+++ b/tests/integration/preflight.ts
@@ -181,7 +181,7 @@ describe('Preflight Test', function() {
           destroyReceiver();
         });
 
-        it('should use region passed in', () => {
+        it('should use edge passed in', () => {
           assert.equal(report?.selectedEdge, selectedEdge);
           assert.equal(report?.edge, edge);
         });

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -90,7 +90,18 @@ describe('PreflightTest', () => {
       const preflight = new PreflightTest('foo', options);
       sinon.assert.calledWith(deviceContext.setup, 'foo', {
         codecPreferences: options.codecPreferences,
-        debug: false
+        debug: false,
+        region: 'gll',
+      });
+    });
+
+    it('should pass region to device', () => {
+      options.region = 'gll';
+      const preflight = new PreflightTest('foo', options);
+      sinon.assert.calledWith(deviceContext.setup, 'foo', {
+        codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
+        debug: false,
+        region: options.region,
       });
     });
   });

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -69,6 +69,7 @@ describe('PreflightTest', () => {
       setup: sinon.stub(),
       connect: sinon.stub().returns(connection),
       destroy: sinon.stub(),
+      region: sinon.stub().returns('foobar-region'),
     };
     deviceFactory = getDeviceFactory(deviceContext)
 
@@ -167,7 +168,7 @@ describe('PreflightTest', () => {
     it('should emit connected', () => {
       const onConnected = sinon.stub();
       const preflight = new PreflightTest('foo', options);
-      
+
       preflight.on('connected', onConnected);
       device.emit('ready');
 
@@ -242,7 +243,9 @@ describe('PreflightTest', () => {
               start: 0
             }
           },
+          region: 'foobar-region',
           samples: testSamples,
+          selectedRegion: 'gll',
           stats: {
             jitter: {
               average: 8,

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -70,6 +70,7 @@ describe('PreflightTest', () => {
       connect: sinon.stub().returns(connection),
       destroy: sinon.stub(),
       region: sinon.stub().returns('foobar-region'),
+      edge: sinon.stub().returns('foobar-edge'),
     };
     deviceFactory = getDeviceFactory(deviceContext)
 
@@ -91,17 +92,17 @@ describe('PreflightTest', () => {
       sinon.assert.calledWith(deviceContext.setup, 'foo', {
         codecPreferences: options.codecPreferences,
         debug: false,
-        region: 'gll',
+        edge: 'roaming',
       });
     });
 
-    it('should pass region to device', () => {
-      options.region = 'gll';
+    it('should pass edge to device', () => {
+      options.edge = 'ashburn';
       const preflight = new PreflightTest('foo', options);
       sinon.assert.calledWith(deviceContext.setup, 'foo', {
         codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
         debug: false,
-        region: options.region,
+        edge: options.edge,
       });
     });
   });
@@ -237,6 +238,7 @@ describe('PreflightTest', () => {
         // This is derived from testSamples
         const expected = {
           callSid: CALL_SID,
+          edge: 'foobar-edge',
           networkTiming: {
             dtls: {
               duration: 1000,
@@ -254,9 +256,8 @@ describe('PreflightTest', () => {
               start: 0
             }
           },
-          region: 'foobar-region',
           samples: testSamples,
-          selectedRegion: 'gll',
+          selectedEdge: 'roaming',
           stats: {
             jitter: {
               average: 8,

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -17,6 +17,7 @@ describe('PreflightTest', () => {
   let deviceContext: any;
   let options: any;
   let testSamples: any;
+  let edgeStub: any;
 
   const getDeviceFactory = (context: any) => {
     const factory = function(this: any, token: string, options: PreflightTest.Options) {
@@ -70,8 +71,10 @@ describe('PreflightTest', () => {
       connect: sinon.stub().returns(connection),
       destroy: sinon.stub(),
       region: sinon.stub().returns('foobar-region'),
-      edge: sinon.stub().returns('foobar-edge'),
+      edge: null,
     };
+    edgeStub = sinon.stub().returns('foobar-edge');
+    sinon.stub(deviceContext, 'edge').get(edgeStub);
     deviceFactory = getDeviceFactory(deviceContext)
 
     options = {
@@ -104,6 +107,7 @@ describe('PreflightTest', () => {
         debug: false,
         edge: options.edge,
       });
+      sinon.assert.calledOnce(edgeStub);
     });
   });
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7483](https://issues.corp.twilio.com/browse/CLIENT-7483)

### Description

This PR adds two parameters to the report that `Preflight Test` emits upon test completion:
- `selectedRegion` the region that was preferred in `PreflightTest.Options`
- `region` the region that the signaling layer ended up connecting to

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
