### PR TITLE
CLIENT-7544 | Fix angular build when used as npm module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 Bug Fixes
 ---------
 
-* Fixed an issue where `rtcSample.rtt` raised by `Connection.on('sample', rtcSample => ...)` was reported in seconds instead of milliseconds in Firefox. If your application is converting `rtcSample.rtt` to milliseconds in Firefox, please update your application to account for this change.
+* Fixed an issue where `rtcSample.rtt` raised by `Connection.on('sample', rtcSample => ...)` was reported in seconds instead of milliseconds in Firefox. If your application is converting `rtcSample.rtt` to milliseconds in Firefox, please update your application to account for this change. (CLIENT-7014)
+* Fixed an issue where an Angular project will not build when the SDK is used as a module. (CLIENT-7544)
 * Fixed an issue where certain device event handlers, when an exception is thrown, causes some connection event handlers to stop working. This causes potential side effects such as incoming ringtone not being able to stop after receiving a call.
   #### Example
   In the following example, `connection.on('accept')` will not trigger if `device.on('connect')` throws an error. With this fix, `connection.on('accept')` handler should now receive the event.

--- a/lib/twilio.ts
+++ b/lib/twilio.ts
@@ -4,7 +4,8 @@
 import { EventEmitter } from 'events';
 import Connection from './twilio/connection';
 import Device from './twilio/device';
-import { PStream } from './twilio/pstream';
+
+const PStream = require('./twilio/pstream');
 
 let instance: Device | null | undefined;
 Object.defineProperty(Device, 'instance', {

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -17,7 +17,6 @@ import {
   SignalingErrors,
 } from './errors';
 import Log from './log';
-import { PStream } from './pstream';
 import {
   defaultRegion,
   getRegionShortcode,
@@ -27,6 +26,7 @@ import { Exception, queryToJson } from './util';
 
 const C = require('./constants');
 const Publisher = require('./eventpublisher');
+const PStream = require('./pstream');
 const rtc = require('./rtc');
 const getUserMedia = require('./rtc/getusermedia');
 const Sound = require('./sound');

--- a/lib/twilio/pstream.js
+++ b/lib/twilio/pstream.js
@@ -257,4 +257,4 @@ function getBrowserInfo() {
   return info;
 }
 
-exports.PStream = PStream;
+module.exports = PStream;

--- a/tests/pstream.js
+++ b/tests/pstream.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
 
-const { PStream } = require('../lib/twilio/pstream');
+const PStream = require('../lib/twilio/pstream');
 const { RELEASE_VERSION } = require('../lib/twilio/constants');
 const TransportFactory = require('./mock/WSTransport');
 

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -55,7 +55,7 @@ describe('Connection', function() {
 
     audioHelper = createEmitterStub(require('../../lib/twilio/audiohelper').default);
     getUserMedia = sinon.spy(() => Promise.resolve(new MediaStream()));
-    pstream = createEmitterStub(require('../../lib/twilio/pstream').PStream);
+    pstream = createEmitterStub(require('../../lib/twilio/pstream'));
     publisher = createEmitterStub(require('../../lib/twilio/eventpublisher'));
     publisher.postMetrics = sinon.spy(() => Promise.resolve());
 

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -39,7 +39,7 @@ describe('Device', function() {
     return activeConnection = createEmitterStub(require('../../lib/twilio/connection').default);
   };
   const pStreamFactory = () =>
-    pstream = createEmitterStub(require('../../lib/twilio/pstream').PStream);
+    pstream = createEmitterStub(require('../../lib/twilio/pstream'));
   const Publisher = () =>
     publisher = createEmitterStub(require('../../lib/twilio/eventpublisher'));
   const soundFactory = (name: Device.SoundName) =>


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7544](https://issues.corp.twilio.com/browse/CLIENT-7544)

### Description

The way we export PStream in js breaks the generated ts declarations. This PR updates how we export it.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
