### PR TITLE
CLIENT-7576 | Handle VSP cancel event if offer sdp is already been an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bug Fixes
 ---------
 
 * Fixed an issue where `rtcSample.rtt` raised by `Connection.on('sample', rtcSample => ...)` was reported in seconds instead of milliseconds in Firefox. If your application is converting `rtcSample.rtt` to milliseconds in Firefox, please update your application to account for this change. (CLIENT-7014)
+* Fixed an issue where a call doesn't get disconnected after the signaling server emits a `cancel` event. (CLIENT-7576)
 * Fixed an issue where an Angular project will not build when the SDK is used as a module. (CLIENT-7544)
 * Fixed an issue where certain device event handlers, when an exception is thrown, causes some connection event handlers to stop working. This causes potential side effects such as incoming ringtone not being able to stop after receiving a call.
   #### Example

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -1105,9 +1105,15 @@ class Connection extends EventEmitter {
     // (rrowland) Is this check necessary? Verify, and if so move to pstream / VSP module.
     const callsid = payload.callsid;
     if (this.parameters.CallSid === callsid) {
-      this._status = Connection.State.Closed;
-      this.emit('cancel');
-      this.pstream.removeListener('cancel', this._onCancel);
+      this.once('disconnect', () => {
+        this._status = Connection.State.Closed;
+        this.emit('cancel');
+        this.pstream.removeListener('cancel', this._onCancel);
+      });
+
+      this._publisher.info('connection', 'cancelled-by-remote', null, this);
+      this._cleanupEventListeners();
+      this.mediaStream.close();
     }
   }
 

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -1111,7 +1111,7 @@ class Connection extends EventEmitter {
         this.pstream.removeListener('cancel', this._onCancel);
       });
 
-      this._publisher.info('connection', 'cancelled-by-remote', null, this);
+      this._publisher.info('connection', 'cancel', null, this);
       this._cleanupEventListeners();
       this.mediaStream.close();
     }

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -1037,7 +1037,9 @@ PeerConnection.prototype.getOrCreateDTMFSender = function getOrCreateDTMFSender(
  * @returns RTCDtlTransport
  */
 PeerConnection.prototype.getRTCDtlsTransport = function getRTCDtlsTransport() {
-  const sender = typeof this.version.pc.getSenders === 'function' && this.version.pc.getSenders()[0];
+  const sender = this.version && this.version.pc
+    && typeof this.version.pc.getSenders === 'function'
+    && this.version.pc.getSenders()[0];
   return sender && sender.transport || null;
 };
 

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -1928,6 +1928,16 @@ describe('PeerConnection', () => {
       toTest = METHOD.bind(context);
     });
 
+    it('Should return null if pc is null', () => {
+      const transport = METHOD.call({ version: {} });
+      assert.equal(transport, null);
+    });
+
+    it('Should return null if version is null', () => {
+      const transport = METHOD.call({});
+      assert.equal(transport, null);
+    });
+
     it('Should return null if getSenders is not supported', () => {
       const transport = toTest();
       assert.equal(transport, null);

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -1212,7 +1212,7 @@ describe('Connection', function() {
           pstream.emit('cancel', { callsid: 'CA123' });
           sinon.assert.called(cleanupStub);
           sinon.assert.called(closeStub);
-          sinon.assert.calledWithExactly(publishStub, 'connection', 'cancelled-by-remote', null, conn);
+          sinon.assert.calledWithExactly(publishStub, 'connection', 'cancel', null, conn);
         });
       });
 

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -1173,13 +1173,31 @@ describe('Connection', function() {
     });
 
     describe('pstream.cancel event', () => {
-      context('when the callsid matches', () => {
-        beforeEach(() => {
-          conn = new Connection(config, Object.assign({
-            callParameters: { CallSid: 'CA123' }
-          }, options));
-        });
+      let conn: any;
+      let cleanupStub: any;
+      let closeStub: any;
+      let publishStub: any;
 
+      beforeEach(() => {
+        cleanupStub = sinon.stub();
+        closeStub = sinon.stub();
+        publishStub = sinon.stub();
+
+        conn = new Connection(config, Object.assign({
+          callParameters: { CallSid: 'CA123' }
+        }, options));
+
+        conn._cleanupEventListeners = cleanupStub;
+        conn.mediaStream.close = () => {
+          closeStub();
+          conn.emit('disconnect');
+        };
+        conn._publisher = {
+          info: publishStub
+        };
+      });
+
+      context('when the callsid matches', () => {
         it('should transition to closed', () => {
           pstream.emit('cancel', { callsid: 'CA123' });
           assert.equal(conn.status(), Connection.State.Closed);
@@ -1188,6 +1206,13 @@ describe('Connection', function() {
         it('should emit a cancel event', (done) => {
           conn.on('cancel', () => done());
           pstream.emit('cancel', { callsid: 'CA123' });
+        });
+
+        it('should disconnect the call', () => {
+          pstream.emit('cancel', { callsid: 'CA123' });
+          sinon.assert.called(cleanupStub);
+          sinon.assert.called(closeStub);
+          sinon.assert.calledWithExactly(publishStub, 'connection', 'cancelled-by-remote', null, conn);
         });
       });
 


### PR DESCRIPTION
…swered

<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7576](https://issues.corp.twilio.com/browse/CLIENT-7576)

### Description

Handle VSP cancel event if offer sdp is already been answered

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
