### PR TITLE
CLIENT-7575 | Log warning for deprecated browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Additions
 ---------
 
 * Added tests for Signaling payloads. (CLIENT-4533)
-* Microsoft Legacy Edge is now deprecated. Running `device.setup()` on this browser will result with a console warning below.
+* Microsoft Legacy Edge is now deprecated. Running `device.setup()` on this browser will result with the console warning below.
   ```
   This browser is deprecated and will not be able to connect to Twilio in the next breaking release.
   Please see this documentation for a list of supported browsers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ Additions
 ---------
 
 * Added tests for Signaling payloads. (CLIENT-4533)
-* Microsoft Legacy Edge is now deprecated. Running `device.setup()` on this browser will result with the console warning below.
+* [Microsoft Edge Legacy](https://support.microsoft.com/en-us/help/4533505/what-is-microsoft-edge-legacy) is now deprecated. Running `device.setup()` on this browser will result with the console warning below.
   ```
-  This browser is deprecated and will not be able to connect to Twilio in the next breaking release.
+  Microsoft Edge Legacy (https://support.microsoft.com/en-us/help/4533505/what-is-microsoft-edge-legacy)
+  is deprecated and will not be able to connect to Twilio to make or receive calls after September 1st, 2020.
   Please see this documentation for a list of supported browsers
   https://www.twilio.com/docs/voice/client/javascript#supported-browsers
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ Features
   });
   ```
 
+Additions
+---------
+
+* Microsoft Legacy Edge is now deprecated. Running `device.setup()` on this browser will result with a console warning below.
+  ```
+  This browser is deprecated and will not be able to connect to Twilio in the next breaking release.
+  Please see this documentation for a list of supported browsers
+  https://www.twilio.com/docs/voice/client/javascript#supported-browsers
+  ```
+
 Bug Fixes
 ---------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,15 @@ Additions
 ---------
 
 * Added tests for Signaling payloads. (CLIENT-4533)
-
-1.10.2 (Apr 22, 2020)
-===================
-
-Additions
----------
-
 * Microsoft Legacy Edge is now deprecated. Running `device.setup()` on this browser will result with a console warning below.
   ```
   This browser is deprecated and will not be able to connect to Twilio in the next breaking release.
   Please see this documentation for a list of supported browsers
   https://www.twilio.com/docs/voice/client/javascript#supported-browsers
   ```
+
+1.10.2 (Apr 22, 2020)
+===================
 
 Bug Fixes
 ---------

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -23,7 +23,7 @@ import {
   getRegionURI,
 } from './regions';
 import {
-  isBrowserDeprecated,
+  isLegacyEdge,
   isUnifiedPlanDefault,
   queryToJson,
 } from './util';
@@ -579,7 +579,7 @@ class Device extends EventEmitter {
         Twilio Support at <help@twilio.com>.`);
     }
 
-    if (isBrowserDeprecated()) {
+    if (isLegacyEdge()) {
       this._log.warn(
         'This browser is deprecated and will not be able to connect to Twilio in the next breaking release. ' +
         'Please see this documentation for a list of supported browsers ' +

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -581,7 +581,8 @@ class Device extends EventEmitter {
 
     if (isLegacyEdge()) {
       this._log.warn(
-        'This browser is deprecated and will not be able to connect to Twilio in the next breaking release. ' +
+        'Microsoft Edge Legacy (https://support.microsoft.com/en-us/help/4533505/what-is-microsoft-edge-legacy) ' +
+        'is deprecated and will not be able to connect to Twilio to make or receive calls after September 1st, 2020. ' +
         'Please see this documentation for a list of supported browsers ' +
         'https://www.twilio.com/docs/voice/client/javascript#supported-browsers',
       );

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -22,7 +22,11 @@ import {
   getRegionShortcode,
   getRegionURI,
 } from './regions';
-import { Exception, queryToJson } from './util';
+import {
+  isBrowserDeprecated,
+  isUnifiedPlanDefault,
+  queryToJson
+} from './util';
 
 const C = require('./constants');
 const Publisher = require('./eventpublisher');
@@ -30,7 +34,6 @@ const PStream = require('./pstream');
 const rtc = require('./rtc');
 const getUserMedia = require('./rtc/getusermedia');
 const Sound = require('./sound');
-const { isUnifiedPlanDefault } = require('./util');
 
 /**
  * @private
@@ -574,6 +577,14 @@ class Device extends EventEmitter {
         For more information, see <https://www.twilio.com/docs/api/client/twilio-js>. \
         If you have any questions about this announcement, please contact \
         Twilio Support at <help@twilio.com>.`);
+    }
+
+    if (isBrowserDeprecated()) {
+      this._log.warn(
+        'This browser is deprecated and will not be able to connect to Twilio in the next breaking release. ' +
+        'Please see this documentation for a list of supported browsers ' +
+        'https://www.twilio.com/docs/voice/client/javascript#supported-browsers'
+      );
     }
 
     if (!token) {

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -25,7 +25,7 @@ import {
 import {
   isBrowserDeprecated,
   isUnifiedPlanDefault,
-  queryToJson
+  queryToJson,
 } from './util';
 
 const C = require('./constants');
@@ -583,7 +583,7 @@ class Device extends EventEmitter {
       this._log.warn(
         'This browser is deprecated and will not be able to connect to Twilio in the next breaking release. ' +
         'Please see this documentation for a list of supported browsers ' +
-        'https://www.twilio.com/docs/voice/client/javascript#supported-browsers'
+        'https://www.twilio.com/docs/voice/client/javascript#supported-browsers',
       );
     }
 

--- a/lib/twilio/rtc/rtcpc.js
+++ b/lib/twilio/rtc/rtcpc.js
@@ -10,7 +10,7 @@ function RTCPC() {
     return;
   }
 
-  if (util.isEdge()) {
+  if (util.isLegacyEdge()) {
     this.RTCPeerConnection = new RTCPeerConnectionShim(typeof window !== 'undefined' ? window : global);
   } else if (typeof window.RTCPeerConnection === 'function') {
     this.RTCPeerConnection = window.RTCPeerConnection;
@@ -44,7 +44,7 @@ RTCPC.prototype.createModernConstraints = c => {
   // 'mandatory' key and does not expect the first letter of each constraint
   // capitalized.
   const nc = Object.assign({}, c);
-  if (typeof webkitRTCPeerConnection !== 'undefined' && !util.isEdge()) {
+  if (typeof webkitRTCPeerConnection !== 'undefined' && !util.isLegacyEdge()) {
     nc.mandatory = {};
     if (typeof c.audio !== 'undefined') {
       nc.mandatory.OfferToReceiveAudio = c.audio;

--- a/lib/twilio/util.js
+++ b/lib/twilio/util.js
@@ -26,10 +26,6 @@ function average(values) {
   return values && values.length ? values.reduce((t, v) => t + v) / values.length : 0;
 }
 
-function isBrowserDeprecated(navigator) {
-  return isLegacyEdge(navigator);
-}
-
 function difference(lefts, rights, getKey) {
   getKey = getKey || (a => a);
   const rightKeys = new Set(rights.map(getKey));
@@ -143,7 +139,6 @@ function flatMap(list, mapFn) {
 
 exports.Exception = TwilioException;
 exports.average = average;
-exports.isBrowserDeprecated = isBrowserDeprecated;
 exports.difference = difference;
 exports.isElectron = isElectron;
 exports.isChrome = isChrome;

--- a/lib/twilio/util.js
+++ b/lib/twilio/util.js
@@ -26,6 +26,10 @@ function average(values) {
   return values && values.length ? values.reduce((t, v) => t + v) / values.length : 0;
 }
 
+function isBrowserDeprecated(navigator) {
+  return isLegacyEdge(navigator);
+}
+
 function difference(lefts, rights, getKey) {
   getKey = getKey || (a => a);
   const rightKeys = new Set(rights.map(getKey));
@@ -55,7 +59,7 @@ function isFirefox(navigator) {
     && /firefox|fxios/i.test(navigator.userAgent);
 }
 
-function isEdge(navigator) {
+function isLegacyEdge(navigator) {
   navigator = navigator || (typeof window === 'undefined'
     ? global.navigator : window.navigator);
 
@@ -139,11 +143,12 @@ function flatMap(list, mapFn) {
 
 exports.Exception = TwilioException;
 exports.average = average;
+exports.isBrowserDeprecated = isBrowserDeprecated;
 exports.difference = difference;
 exports.isElectron = isElectron;
 exports.isChrome = isChrome;
 exports.isFirefox = isFirefox;
-exports.isEdge = isEdge;
+exports.isLegacyEdge = isLegacyEdge;
 exports.isSafari = isSafari;
 exports.isUnifiedPlanDefault = isUnifiedPlanDefault;
 exports.queryToJson = queryToJson;

--- a/tests/util.js
+++ b/tests/util.js
@@ -42,25 +42,31 @@ describe('Util', () => {
     });
   });
 
-  describe('isEdge', () => {
+  describe('isLegacyEdge', () => {
     it('correctly parses non edge user agent strings', () => {
-      assert(!util.isEdge({ userAgent: 'Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0' }));
-      assert(!util.isEdge({ userAgent: 'Mozilla/5.0 (Windows NT x.y; rv:10.0) Gecko/20100101 Firefox/10.0' }));
-      assert(!util.isEdge({ userAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0' }));
-      assert(!util.isEdge({ userAgent: 'Mozilla/5.0 (X11; Linux i686 on x86_64; rv:10.0) Gecko/20100101 Firefox/10.0' }));
-      assert(!util.isEdge({ userAgent: 'Mozilla/5.0 (Tablet; rv:26.0) Gecko/26.0 Firefox/26.0' }));
-      assert(!util.isEdge({ userAgent: 'Mozilla/5.0 (iPod touch; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4' }));
-      assert(!util.isEdge({ userAgent: 'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4' }));
-      assert(!util.isEdge({ userAgent: 'Mozilla/5.0 (Maemo; Linux armv7l; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 Fennec/10.0.1' }));
-      assert(!util.isEdge({ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.5; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 SeaMonkey/2.7.1' }));
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0' }));
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (Windows NT x.y; rv:10.0) Gecko/20100101 Firefox/10.0' }));
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0' }));
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (X11; Linux i686 on x86_64; rv:10.0) Gecko/20100101 Firefox/10.0' }));
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (Tablet; rv:26.0) Gecko/26.0 Firefox/26.0' }));
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (iPod touch; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4' }));
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4' }));
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (Maemo; Linux armv7l; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 Fennec/10.0.1' }));
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.5; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 SeaMonkey/2.7.1' }));
     });
 
     it('correctly parses edge user agent strings', () => {
-      assert(util.isEdge({ userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246' }));
-      assert(util.isEdge({ userAgent: 'Mozilla/5.0 (X11; CrOS x86_64 6783.1.0) AppleWebKit/537.36 (KHTML, like Gecko) Edge/12.0' }));
-      assert(util.isEdge({ userAgent: 'Mozilla/5.0 (Windows NT 6.3; Win64, x64; Touch) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0 (Touch; Trident/7.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; HPNTDFJS; H9P; InfoPath' }));
-      assert(util.isEdge({ userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/538.36 (KHTML, like Gecko) Edge/12.10240' }));
-      assert(util.isEdge({ userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.9600' }));
+      assert(util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246' }));
+      assert(util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (X11; CrOS x86_64 6783.1.0) AppleWebKit/537.36 (KHTML, like Gecko) Edge/12.0' }));
+      assert(util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (Windows NT 6.3; Win64, x64; Touch) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0 (Touch; Trident/7.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; HPNTDFJS; H9P; InfoPath' }));
+      assert(util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/538.36 (KHTML, like Gecko) Edge/12.10240' }));
+      assert(util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.9600' }));
+    });
+
+    it('correctly parses chromium edge user agent strings', () => {
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43' }));
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1' }));
+      assert(!util.isLegacyEdge({ userAgent: 'Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1' }));
     });
   });
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7575](https://issues.corp.twilio.com/browse/CLIENT-7575)

### Description

As part of Microsoft Legacy Edge EOL, we need to log a warning before fully removing support in Sept 2020. This PR logs a warning about deprecating Legacy Edge after calling `device.setup()` 
See EOL plan for more details.
https://docs.google.com/document/d/1CeLIr7Wr4wQBUbS3KllUn7iOHXKCXYXL5GxkOoNHDVM/edit#heading=h.um8h927b0i56

Source for detecting Legacy Edge vs Chromium Edge:
https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-string

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
