### PR TITLE
CLIENT-7652 | Don't fallback edge when coming from connected

### DIFF
--- a/tests/integration/edgefallback.ts
+++ b/tests/integration/edgefallback.ts
@@ -107,7 +107,7 @@ describe('Edge Fallback', function() {
     // Trigger network error
     await runDockerCommand('disconnectFromAllNetworks');
 
-    let usedUri: string;
+    let usedUri: string = '';
     await waitFor(new Promise((resolve) => {
       device.stream.transport.__WebSocket = device.stream.transport._WebSocket;
       device.stream.transport._WebSocket = function(uri: string) {

--- a/tests/integration/edgefallback.ts
+++ b/tests/integration/edgefallback.ts
@@ -86,7 +86,7 @@ describe('Edge Fallback', function() {
     assert.equal(device.stream.transport.uri, 'wss://chunderw-vpc-gll-au1.twilio.com/signal');
   });
 
-  it('should fallback to the next edge if the transport error is fallback-able while connected', async () => {
+  it('should not fallback to the next edge if the transport error is fallback-able while connected', async () => {
     const timeout = 100000;
     device.setup(token, Object.assign({}, defaultOptions, { edge: ['sydney', 'singapore'] }));
     await deviceReady();
@@ -96,7 +96,6 @@ describe('Edge Fallback', function() {
     // Trigger network error
     await runDockerCommand('disconnectFromAllNetworks');
 
-    // Check the reconnect and make sure the uri used is a fallback
     await waitFor(new Promise((resolve) => {
       device.on('error', (error: any) => {
         if (error.code === 31005) {
@@ -104,7 +103,7 @@ describe('Edge Fallback', function() {
         }
       });
     }), timeout);
-    assert.equal(device.stream.transport.uri, 'wss://chunderw-vpc-gll-sg1.twilio.com/signal');
+    assert.equal(device.stream.transport.uri, 'wss://chunderw-vpc-gll-au1.twilio.com/signal');
 
     await runDockerCommand('resetNetwork');
     await pause(5000);

--- a/tests/integration/edgefallback.ts
+++ b/tests/integration/edgefallback.ts
@@ -78,32 +78,46 @@ describe('Edge Fallback', function() {
     const invalidToken = (JSON.parse(res) as any).token;
     device.updateToken(invalidToken);
 
-    // Check at least two reconnects and make sure the uri did not use a fallback
-    await waitFor(expectEvent('error', device), EVENT_TIMEOUT);
-    assert.equal(device.stream.transport.uri, 'wss://chunderw-vpc-gll-au1.twilio.com/signal');
+    const usedUris: string[] = [];
+    const timeout = 100000;
+    await waitFor(new Promise((resolve) => {
+      device.stream.transport.__WebSocket = device.stream.transport._WebSocket;
+      device.stream.transport._WebSocket = function(uri: string) {
+        usedUris.push(uri);
+        // Check at least two reconnects and make sure the uri did not use a fallback
+        if (usedUris.length >= 2) {
+          setTimeout(resolve);
+        }
+        return new device.stream.transport.__WebSocket(uri);
+      };
+    }), timeout);
 
-    await waitFor(expectEvent('error', device), EVENT_TIMEOUT);
-    assert.equal(device.stream.transport.uri, 'wss://chunderw-vpc-gll-au1.twilio.com/signal');
+    assert.equal(usedUris[0], 'wss://chunderw-vpc-gll-au1.twilio.com/signal');
+    assert.equal(usedUris[1], 'wss://chunderw-vpc-gll-au1.twilio.com/signal');
   });
 
-  it('should not fallback to the next edge if the transport error is fallback-able while connected', async () => {
-    const timeout = 100000;
+  it('should not fallback to the next edge if the transport error is fallback-able while connected', async function() {
+    this.timeout(MAX_TIMEOUT);
+    const connectTimeout = 120000;
     device.setup(token, Object.assign({}, defaultOptions, { edge: ['sydney', 'singapore'] }));
     await deviceReady();
     assert.equal(device.stream.transport.uri, 'wss://chunderw-vpc-gll-au1.twilio.com/signal');
-    device.stream.transport['_connectTimeoutMs'] = timeout;
+    device.stream.transport['_connectTimeoutMs'] = connectTimeout;
 
     // Trigger network error
     await runDockerCommand('disconnectFromAllNetworks');
 
+    let usedUri: string;
     await waitFor(new Promise((resolve) => {
-      device.on('error', (error: any) => {
-        if (error.code === 31005) {
-          resolve();
-        }
-      });
-    }), timeout);
-    assert.equal(device.stream.transport.uri, 'wss://chunderw-vpc-gll-au1.twilio.com/signal');
+      device.stream.transport.__WebSocket = device.stream.transport._WebSocket;
+      device.stream.transport._WebSocket = function(uri: string) {
+        usedUri = uri;
+        setTimeout(resolve);
+        return new device.stream.transport.__WebSocket(uri);
+      };
+    }), connectTimeout);
+
+    assert.equal(usedUri, 'wss://chunderw-vpc-gll-au1.twilio.com/signal');
 
     await runDockerCommand('resetNetwork');
     await pause(5000);


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7652](https://issues.corp.twilio.com/browse/CLIENT-7652)

### Description

Still needs tests but an initial review on the solution would help. I'm not 100% happy with the approach but this seems to be the simplest solution I found considering different browser behaviors. I intentionally made it verbose for readability.

EDIT: This is now ready. I removed isSafari check and added a fallback counter instead to cover all browsers.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
