### PR TITLE
[CLIENT-7502] Emit samples even when MOS is `null`.

### DIFF
--- a/PREFLIGHT_TWIML.md
+++ b/PREFLIGHT_TWIML.md
@@ -17,6 +17,8 @@ Create a new TwiML Bin with the plus button on that screen and use `Playback` as
 <Response>
   <Say>You said:</Say>
   <Play loop="1">{{RecordingUrl}}</Play>
+  <Say>Now waiting for a few seconds to gather audio performance metrics.</Say>
+  <Pause length="3">
   <Say>Hanging up now.</Say>
 </Response>
 ```

--- a/PREFLIGHT_TWIML.md
+++ b/PREFLIGHT_TWIML.md
@@ -31,7 +31,7 @@ Using the [TwiML Bin](https://www.twilio.com/console/twiml-bins) page, let's cre
 
 <Response>
   <Say>Record a message in 3, 2, 1</Say>
-  <Record maxLength="3" action="https://my-record-twiml-url"></Record>
+  <Record maxLength="5" action="https://my-record-twiml-url"></Record>
   <Say>Did not detect a message to record</Say>
 </Response>
 ```

--- a/lib/twilio/rtc/sample.ts
+++ b/lib/twilio/rtc/sample.ts
@@ -43,7 +43,7 @@ export default interface RTCSample {
   /**
    * Mean opinion score, 1.0 through roughly 4.5
    */
-  mos: number;
+  mos: number | null;
 
   /**
    * Number of packets lost in last second.


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7502](https://issues.corp.twilio.com/browse/CLIENT-7502)

### Description

This PR introduces a change to Preflight Test such that samples emitted by the connection are also emitted by the test even when MOS is `null`.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
