### PR TITLE
Disabling flaky firefox test for now

### DIFF
--- a/tests/integration/reconnection.ts
+++ b/tests/integration/reconnection.ts
@@ -170,7 +170,8 @@ describe('Reconnection', function() {
     });
   });
 
-  describe('When network disconnects', function() {
+  // TODO: Re-enable after CLIENT-7771
+  (isFirefox() ? describe.skip : describe)('When network disconnects', function() {
     this.timeout(USE_CASE_TIMEOUT);
 
     before(() => setupDevices());


### PR DESCRIPTION
Tests in docker that requires turning on/off network multiple times now causes errors in latest firefox, where karma loses handle. Adding a longer timer doesn't seem to fix it. Disabling the test for now and we can probably fix this by implementing a way to run test suites in separate docker containers. Filed ticket https://issues.corp.twilio.com/browse/CLIENT-7771