### PR TITLE
more error handling around access to this.version.pc

### DIFF
--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -996,6 +996,10 @@ PeerConnection.prototype.getOrCreateDTMFSender = function getOrCreateDTMFSender(
   }
 
   const self = this;
+  if (!this.version) {
+    this._log.info('No RTCPeerConnection available to call createDTMFSender on');
+    return null;
+  }
   const pc = this.version.pc;
   if (!pc) {
     this._log.info('No RTCPeerConnection available to call createDTMFSender on');


### PR DESCRIPTION
It's possible for getOrCreateDTMFSender to be called with this.version still null.   A solution would be to check the value of version before accessing pc.

<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-0000](https://issues.corp.twilio.com/browse/CLIENT-0000)

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
