### PR TITLE
CLIENT-7674 | Adding connection setup warning events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+1.13.0 (In progress)
+====================
+
+Additions
+---------
+
+### New Network Quality Warnings
+This release includes new network quality warnings that are raised via `Connection.on('warning', handler(name))` event. You can use these warnings to show visual indicators that alert the end user to a problem.
+
+* `high-ice-connect-duration` - Raised when [ICE connection](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState) takes over 500ms to establish, which is measured from RTCPeerConnection.iceConnectionState:checking to RTCPeerConnection.iceConnectionState:connected. This value represents how long the client and media server took to establish a connection to exchange media. This warning does not have a corresponding warning-cleared event.
+* `high-dtls-connect-duration` - Raised when [DTLS transport](https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport/state) takes over 1300ms to establish, which is measured from RTCDtlsTransport.state:connecting to RTCDtlsTransport.state:connected. This value represents how long the client and media server took to negotiate a secure connection. This warning does not have a corresponding warning-cleared event.
+* `high-pc-connect-duration` - Raised when [RTCPeerConnection](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionState) takes over 1800ms to establish, which is measured from RTCPeerConnection.connectionState:connecting to RTCPeerConnection.connectionState:connected. This value represents how long the client and media server took to establish the ICE and DTLS connection. This warning does not have a corresponding warning-cleared event.
+
+**Example**
+```ts
+connection.on('warning', (warningName) => {
+  if (warningName === 'high-pc-connect-duration') {
+    console.log('We have detected poor network conditions. You may experience an initial media delay on future calls.');
+  }
+});
+```
+
 1.12.0 (June 11, 2020)
 ====================
 

--- a/lib/twilio.ts
+++ b/lib/twilio.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @internalapi
  */
 import { EventEmitter } from 'events';

--- a/lib/twilio/asyncQueue.ts
+++ b/lib/twilio/asyncQueue.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Voice
  * @internalapi
  */

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Voice
  */
 import { EventEmitter } from 'events';

--- a/lib/twilio/deferred.ts
+++ b/lib/twilio/deferred.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Voice
  * @internalapi
  */

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Voice
  * @preferred
  * @publicapi

--- a/lib/twilio/dialtonePlayer.ts
+++ b/lib/twilio/dialtonePlayer.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Tools
  * @internalapi
  */

--- a/lib/twilio/errors/index.ts
+++ b/lib/twilio/errors/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @internalapi
  */
 /* tslint:disable max-classes-per-file */

--- a/lib/twilio/errors/twilioError.ts
+++ b/lib/twilio/errors/twilioError.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Voice
  * @publicapi
  * @internal

--- a/lib/twilio/log.ts
+++ b/lib/twilio/log.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Voice
  * @internalapi
  */

--- a/lib/twilio/outputdevicecollection.ts
+++ b/lib/twilio/outputdevicecollection.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Voice
  */
 import { SOUNDS_BASE_URL } from './constants';

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Voice
  * This module describes valid and deprecated regions.
  */

--- a/lib/twilio/rtc/candidate.ts
+++ b/lib/twilio/rtc/candidate.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Voice
  * @internalapi
  */

--- a/lib/twilio/rtc/warning.ts
+++ b/lib/twilio/rtc/warning.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Voice
  * @internalapi
  */

--- a/lib/twilio/statsMonitor.ts
+++ b/lib/twilio/statsMonitor.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Voice
  * @internalapi
  */

--- a/lib/twilio/timing.ts
+++ b/lib/twilio/timing.ts
@@ -1,0 +1,78 @@
+/**
+ * @packageDocumentation
+ * @module Voice
+ * @publicapi
+ */
+
+/**
+ * Timing measurements that provides operational milestones.
+ */
+export interface TimeMeasurement {
+  /**
+   * Number milliseconds elapsed for this measurement
+   */
+  duration?: number;
+
+  /**
+   * A millisecond timestamp the represents the end of a process
+   */
+  end?: number;
+
+  /**
+   * A millisecond timestamp the represents the start of a process
+   */
+  start: number;
+}
+
+/**
+ * Represents a warning configuration for a specific timing metric.
+ */
+export interface TimingWarningConfig {
+  /**
+   * The end state for when to stop measuring time.
+   * The [[TimeMeasurement.end]] is captured when this state is reached.
+   */
+  endState: string;
+
+  /**
+   * The name of the warning.
+   */
+  name: string;
+
+  /**
+   * The start state for when to start measuring time.
+   * The [[TimeMeasurement.start]] is captured when this state is reached.
+   */
+  startState: string;
+
+  /**
+   * [[TimingWarningConfig.name]] warning is raised when [[TimeMeasurement.duration]] exceeds the threshold value.
+   */
+  threshold: number;
+}
+
+/**
+ * Represents network related time measurements.
+ */
+export interface NetworkTiming {
+  /**
+   * Measurements for establishing DTLS connection.
+   * This is measured from RTCDtlsTransport `connecting` to `connected` state.
+   * See [RTCDtlsTransport state](https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport/state).
+   */
+  dtls?: TimeMeasurement;
+
+  /**
+   * Measurements for establishing ICE connection.
+   * This is measured from ICE connection `checking` to `connected` state.
+   * See [RTCPeerConnection.iceConnectionState](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState).
+   */
+  ice?: TimeMeasurement;
+
+  /**
+   * Measurements for establishing a PeerConnection.
+   * This is measured from PeerConnection `connecting` to `connected` state.
+   * See [RTCPeerConnection.connectionState](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionState).
+   */
+  peerConnection?: TimeMeasurement;
+}

--- a/lib/twilio/wstransport.ts
+++ b/lib/twilio/wstransport.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * @module Tools
  * @internalapi
  */

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,7 @@
     "arrow-parens": false,
     "ban-types": false,
     "interface-name": false,
+    "max-line-length": [true, 200],
     "member-access": [true, "no-public"],
     "member-ordering": [true, {
       "order": "statics-first",


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7674](https://issues.corp.twilio.com/browse/CLIENT-7674)

### Description

This PR implements new connection setup warnings.

The thresholds represents P95 of setup time on JS. See discussion [here](https://code.hq.twilio.com/client/voice-sdk-api/pull/43#discussion_r558594).

See [IDL](https://code.hq.twilio.com/client/voice-sdk-api/blob/master/idl/callobserver.md) and [Insights Spec](https://code.hq.twilio.com/client/rtc-insights-spec#warning-raised-events).

See original PRs for [IDL](https://code.hq.twilio.com/client/voice-sdk-api/pull/43) and [Insights Spec](https://code.hq.twilio.com/client/rtc-insights-spec/pull/57).

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
