### PR TITLE
CLIENT-7786 | [Preflight] Fix output not muting for non default device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.13.0-preview2 (In progress)
+=============================
+
+Bug Fixes
+---------
+
+* Fixed an issue where preflight is not muting the audio output after output audio devices are updated.
+
 1.13.0-preview1 (June 17, 2020)
 ===============================
 

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -18,6 +18,7 @@ import { NetworkTiming, TimeMeasurement } from './timing';
 const { COWBELL_AUDIO_URL, ECHO_TEST_DURATION } = require('../constants');
 
 /**
+ * Placeholder until we convert peerconnection.js to TypeScript.
  * Represents the audio output object coming from Client SDK's PeerConnection object.
  * @internalapi
  */
@@ -471,10 +472,11 @@ export class PreflightTest extends EventEmitter {
    */
   private _setupConnectionHandlers(connection: Connection): void {
     if (this._options.fakeMicInput) {
-      // Mute all audio outputs
+      // When volume events start emitting, it means all audio outputs have been created.
+      // Let's mute them if we're using fake mic input.
       connection.once('volume', () => {
         connection.mediaStream.outputs
-          .forEach((output: any) => output.audio.muted = true);
+          .forEach((output: AudioOutput) => output.audio.muted = true);
       });
     }
 

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -17,6 +17,17 @@ import { NetworkTiming, TimeMeasurement } from './timing';
 
 const { COWBELL_AUDIO_URL, ECHO_TEST_DURATION } = require('../constants');
 
+/**
+ * Represents the audio output object coming from Client SDK's PeerConnection object.
+ * @internalapi
+ */
+export interface AudioOutput {
+  /**
+   * The audio element used to play out the sound.
+   */
+  audio: HTMLAudioElement;
+}
+
 export declare interface PreflightTest {
   /**
    * Raised when [[PreflightTest.status]] has transitioned to [[PreflightTest.Status.Completed]].
@@ -459,6 +470,14 @@ export class PreflightTest extends EventEmitter {
    * @param connection
    */
   private _setupConnectionHandlers(connection: Connection): void {
+    if (this._options.fakeMicInput) {
+      // Mute all audio outputs
+      connection.once('volume', () => {
+        connection.mediaStream.outputs
+          .forEach((output: any) => output.audio.muted = true);
+      });
+    }
+
     connection.on('warning', (name: string, data: RTCWarning) => {
       // Constant audio warnings are handled by StatsMonitor
       if (name.includes('constant-audio')) {

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -71,13 +71,15 @@ describe('PreflightTest', () => {
     };
 
     const outputs = new Map();
-    outputs.set('default', { audio: {} })
+    outputs.set('default', { audio: {} });
+    outputs.set('foo', { audio: {} });
     connectionContext = {
       _monitor: monitor,
       mediaStream: {
         callSid: CALL_SID,
-        _masterAudio: {},
+        _onAddTrack: () => {},
         _fallbackOnAddTrack: () => {},
+        _updateAudioOutputs: () => {},
         version: { pc: {} },
         onpcconnectionstatechange: sinon.stub(),
         oniceconnectionstatechange: sinon.stub(),
@@ -338,29 +340,29 @@ describe('PreflightTest', () => {
       });
     });
 
-    it('should mute media stream if fakeMicInput is true', () => {
-      preflight = new PreflightTest('foo', {...options, fakeMicInput: true });
+    ['onAddTrack', 'fallbackOnAddTrack', 'updateAudioOutputs'].forEach(handler => {
+      it(`should not mute media stream if fakeMicInput is false and pc.${handler} is called`, () => {
+        preflight = new PreflightTest('foo', options);
 
-      return wait().then(() => {
-        device.emit('ready');
-        connection.emit('accept');
-        connectionContext.mediaStream._fallbackOnAddTrack();
+        return wait().then(() => {
+          device.emit('ready');
+          connectionContext.mediaStream[`_${handler}`]();
 
-        assert(connectionContext.mediaStream.outputs.get('default').audio.muted);
-        assert(connectionContext.mediaStream._masterAudio.muted);
+          assert(!connectionContext.mediaStream.outputs.get('default').audio.muted);
+          assert(!connectionContext.mediaStream.outputs.get('foo').audio.muted);
+        });
       });
-    });
 
-    it('should not mute media stream if fakeMicInput is false', () => {
-      preflight = new PreflightTest('foo', options);
+      it(`should mute media stream if fakeMicInput is true and pc.${handler} is called`, () => {
+        preflight = new PreflightTest('foo', {...options, fakeMicInput: true });
 
-      return wait().then(() => {
-        device.emit('ready');
-        connection.emit('accept');
-        connectionContext.mediaStream._fallbackOnAddTrack();
+        return wait().then(() => {
+          device.emit('ready');
+          connectionContext.mediaStream[`_${handler}`]();
 
-        assert(!connectionContext.mediaStream.outputs.get('default').audio.muted);
-        assert(!connectionContext.mediaStream._masterAudio.muted);
+          assert(connectionContext.mediaStream.outputs.get('default').audio.muted);
+          assert(connectionContext.mediaStream.outputs.get('foo').audio.muted);
+        });
       });
     });
   });

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -77,9 +77,6 @@ describe('PreflightTest', () => {
       _monitor: monitor,
       mediaStream: {
         callSid: CALL_SID,
-        _onAddTrack: () => {},
-        _fallbackOnAddTrack: () => {},
-        _updateAudioOutputs: () => {},
         version: { pc: {} },
         onpcconnectionstatechange: sinon.stub(),
         oniceconnectionstatechange: sinon.stub(),
@@ -340,29 +337,25 @@ describe('PreflightTest', () => {
       });
     });
 
-    ['onAddTrack', 'fallbackOnAddTrack', 'updateAudioOutputs'].forEach(handler => {
-      it(`should not mute media stream if fakeMicInput is false and pc.${handler} is called`, () => {
-        preflight = new PreflightTest('foo', options);
+    it('should not mute media stream if fakeMicInput is false', () => {
+      preflight = new PreflightTest('foo', options);
 
-        return wait().then(() => {
-          device.emit('ready');
-          connectionContext.mediaStream[`_${handler}`]();
-
-          assert(!connectionContext.mediaStream.outputs.get('default').audio.muted);
-          assert(!connectionContext.mediaStream.outputs.get('foo').audio.muted);
-        });
+      return wait().then(() => {
+        device.emit('ready');
+        connection.emit('volume');
+        assert(!connectionContext.mediaStream.outputs.get('default').audio.muted);
+        assert(!connectionContext.mediaStream.outputs.get('foo').audio.muted);
       });
+    });
 
-      it(`should mute media stream if fakeMicInput is true and pc.${handler} is called`, () => {
-        preflight = new PreflightTest('foo', {...options, fakeMicInput: true });
+    it('should mute media stream if fakeMicInput is true', () => {
+      preflight = new PreflightTest('foo', {...options, fakeMicInput: true });
 
-        return wait().then(() => {
-          device.emit('ready');
-          connectionContext.mediaStream[`_${handler}`]();
-
-          assert(connectionContext.mediaStream.outputs.get('default').audio.muted);
-          assert(connectionContext.mediaStream.outputs.get('foo').audio.muted);
-        });
+      return wait().then(() => {
+        device.emit('ready');
+        connection.emit('volume');
+        assert(connectionContext.mediaStream.outputs.get('default').audio.muted);
+        assert(connectionContext.mediaStream.outputs.get('foo').audio.muted);
       });
     });
   });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7786](https://issues.corp.twilio.com/browse/CLIENT-7786)

### Description

This PR fixes an issue where master audio is not muted after changing device. This PR is now making sure all output audio are muted whenever clientjs updates the output.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
