### PR TITLE
[PR202]Ensure add/removeEventListener methods are present for connection

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -477,7 +477,7 @@ class Device extends EventEmitter {
       this.stream = null;
     }
 
-    if (networkInformation) {
+    if (networkInformation && typeof networkInformation.removeEventListener === 'function') {
       networkInformation.removeEventListener('change', this._publishNetworkChange);
     }
 
@@ -735,7 +735,7 @@ class Device extends EventEmitter {
       this._publisher.disable();
     }
 
-    if (networkInformation) {
+    if (networkInformation && typeof networkInformation.addEventListener === 'function') {
       networkInformation.addEventListener('change', this._publishNetworkChange);
     }
 


### PR DESCRIPTION
We have observed the following error happening with
`Chrome Mobile WebView`:
```
networkInformation.addEventListener is not a function
```

This commit checks if `networkInformation.addEventListener` and
`networkInformation.removeEventListener` are functions before using
them.

<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-0000](https://issues.corp.twilio.com/browse/CLIENT-0000)

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
