### PR TITLE
CLIENT-7995 | Handling out of sequence ICE Gathering events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.12.2 (In Progress)
+====================
+
+Bug Fixes
+---------
+
+* Fixed an issue where calls on Safari 13.1.2 will intermittently raise a 31003 error.
+
 1.12.1 (June 29, 2020)
 ====================
 

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -708,7 +708,6 @@ PeerConnection.prototype._setupChannel = function() {
   pc.onicegatheringstatechange = () => {
     const state = pc.iceGatheringState;
     if (state === 'gathering') {
-      this._hasIceCandidates = false;
       this._startIceGatheringTimeout();
 
     } else if (state === 'complete') {
@@ -797,6 +796,7 @@ PeerConnection.prototype.iceRestart = function() {
     return;
   }
   this._log.info('Attempting to restart ICE...');
+  this._hasIceCandidates = false;
   this.version.createOffer(this.options.maxAverageBitrate, this.codecPreferences, { iceRestart: true }).then(() => {
     this._removeReconnectionListeners();
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7995](https://issues.corp.twilio.com/browse/CLIENT-7995)

### Description

During the ICE Gathering phase, the following steps should happen in order per WebRTC spec.

1. ICE Gathering starts
2. ICE Gathering State changes to "gathering"
3. A local ICE Candidate is gathered, and On ICE Candidate event is triggered
4. ICE Gathering State changes to "complete"

All major browsers support the above sequence. Until recently, Safari 13.1.2 has changed in behavior. The following sequence describes the new behavior.

1. ICE Gathering starts
2. A local ICE Candidate is gathered, and On ICE Candidate event is triggered
3. ICE Gathering State changes to "gathering"
4. ICE Gathering State changes to "complete"

VoiceJS starts checking for candidates after ICE Gathering State transitions to "gathering" (by setting `hasIceCandidates` flag to false). With the wrong order of events on Safari 13.1.2, VoiceJS thinks there are no ICE Candidates gathered when ICE Gathering State transitions to "complete", which causes an ICE Failure (31003).

This PR addresses that issue. We now set `hasIceCandidates` when we initialize the `Connection` and when an `iceRestart` is triggered.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
