### PR TITLE
CLIENT-7909 | Clean up transportClose event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Additions
 ---------
 
+* Fixed an issue where the transportClose event listener was not being cleaned up appropriately when a Connection closed.
 * We now log selected [ICE candidate pair](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePair) to Insights. This will help with isolating issues should they arise.
 
 1.12.2 (August 6, 2020)

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -470,11 +470,7 @@ class Connection extends EventEmitter {
     this.pstream = config.pstream;
     this.pstream.on('cancel', this._onCancel);
     this.pstream.on('ringing', this._onRinging);
-
-    this.pstream.on('transportClose', () => {
-      this._log.error('Received transportClose from pstream');
-      this.emit('transportClose');
-    });
+    this.pstream.on('transportClose', this._onTransportClose);
 
     this.on('error', error => {
       this._publisher.error('connection', 'error', {
@@ -985,6 +981,7 @@ class Connection extends EventEmitter {
       this.pstream.removeListener('cancel', this._onCancel);
       this.pstream.removeListener('hangup', this._onHangup);
       this.pstream.removeListener('ringing', this._onRinging);
+      this.pstream.removeListener('transportClose', this._onTransportClose);
     };
 
     // This is kind of a hack, but it lets us avoid rewriting more code.
@@ -1320,6 +1317,16 @@ class Connection extends EventEmitter {
     }
 
     this.emit('sample', sample);
+  }
+
+  /**
+   * Called when we receive a transportClose event from pstream.
+   * Re-emits the event.
+   * @param sample
+   */
+  private _onTransportClose = (): void => {
+    this._log.error('Received transportClose from pstream');
+    this.emit('transportClose');
   }
 
   /**

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -977,11 +977,7 @@ class Connection extends EventEmitter {
     const cleanup = () => {
       if (!this.pstream) { return; }
 
-      this.pstream.removeListener('answer', this._onAnswer);
-      this.pstream.removeListener('cancel', this._onCancel);
-      this.pstream.removeListener('hangup', this._onHangup);
-      this.pstream.removeListener('ringing', this._onRinging);
-      this.pstream.removeListener('transportClose', this._onTransportClose);
+      this.pstream.removeAllListeners('answer');
     };
 
     // This is kind of a hack, but it lets us avoid rewriting more code.
@@ -1322,7 +1318,6 @@ class Connection extends EventEmitter {
   /**
    * Called when we receive a transportClose event from pstream.
    * Re-emits the event.
-   * @param sample
    */
   private _onTransportClose = (): void => {
     this._log.error('Received transportClose from pstream');

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -977,7 +977,11 @@ class Connection extends EventEmitter {
     const cleanup = () => {
       if (!this.pstream) { return; }
 
-      this.pstream.removeAllListeners('answer');
+      this.pstream.removeListener('answer', this._onAnswer);
+      this.pstream.removeListener('cancel', this._onCancel);
+      this.pstream.removeListener('hangup', this._onHangup);
+      this.pstream.removeListener('ringing', this._onRinging);
+      this.pstream.removeListener('transportClose', this._onTransportClose);
     };
 
     // This is kind of a hack, but it lets us avoid rewriting more code.

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -676,7 +676,6 @@ describe('Connection', function() {
       context(`when state is ${state}`, () => {
         beforeEach(() => {
           (conn as any)['_status'] = state;
-          pstream.removeAllListeners = sinon.spy();
         });
 
         it('should call pstream.hangup', () => {
@@ -689,11 +688,18 @@ describe('Connection', function() {
           sinon.assert.calledOnce(mediaStream.close);
         });
 
-        it('should call pstream.removeAllListeners', () => {
-          conn.disconnect();
-          sinon.assert.calledOnce(pstream.removeAllListeners);
-          clock.tick(10);
-          sinon.assert.calledTwice(pstream.removeAllListeners);
+        [
+          'answer',
+          'cancel',
+          'hangup',
+          'ringing',
+          'transportClose',
+        ].forEach((eventName: string) => {
+          it(`should call pstream.removeListener on ${eventName}`, () => {
+            conn.disconnect();
+            clock.tick(10);
+            assert.equal(pstream.listenerCount(eventName), 0);
+          });
         });
       });
     });

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -676,6 +676,7 @@ describe('Connection', function() {
       context(`when state is ${state}`, () => {
         beforeEach(() => {
           (conn as any)['_status'] = state;
+          pstream.removeAllListeners = sinon.spy();
         });
 
         it('should call pstream.hangup', () => {
@@ -686,6 +687,13 @@ describe('Connection', function() {
         it('should call mediaStream.close', () => {
           conn.disconnect();
           sinon.assert.calledOnce(mediaStream.close);
+        });
+
+        it('should call pstream.removeAllListeners', () => {
+          conn.disconnect();
+          sinon.assert.calledOnce(pstream.removeAllListeners);
+          clock.tick(10);
+          sinon.assert.calledTwice(pstream.removeAllListeners);
         });
       });
     });


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):

- [CLIENT-7909](https://issues.corp.twilio.com/browse/CLIENT-7909)

### Description

Unbinds the transportClose event when we destroy the Connection.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
