### PR TITLE
CLIENT-7480 | Preflight network handover results with error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ Changes
   | `PreflightTest.Report.selectedIceCandidatePair` | `PreflightTest.Report.selectedIceCandidatePairStats` |
 --------------------------
 
+Bug Fixes
+---------
+
+* Fixed an issue where the browser console is flooded with errors after a network handover.
+
 1.13.0-beta1 (July 7, 2020)
 =============================
 

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -361,11 +361,11 @@ export class PreflightTest extends EventEmitter {
       return;
     }
 
-    this._device.on('ready', () => {
+    this._device.once('ready', () => {
       this._onDeviceReady();
     });
 
-    this._device.on('error', (error: Device.Error) => {
+    this._device.once('error', (error: Device.Error) => {
       this._onDeviceError(error);
     });
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7480](https://issues.corp.twilio.com/browse/CLIENT-7480)

### Description

When network handover happens on FF and Safari, websocket drops right away which causes a bunch of errors thrown due to retries and queued messages which is normal. As a side effect on preflight, our error handler is called multiple times and onFailed is raised multiple times. This PR updates that so we only listen to error once.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
