### PR TITLE
CLIENT-8023 | Deprecate Edge Legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Bug Fixes
 
 * Fixed an issue where an error is thrown if `Device` is imported and run in a NodeJS environment.
 
+Changes
+-------
+
+* The twilio.js SDK no longer supports the deprecated Edge Legacy browsers that rely on ORTC. See [our deprecation notice](https://support.twilio.com/hc/en-us/articles/360047874793-Twilio-Client-JavaScript-SDK-twilio-js-Microsoft-Edge-Legacy-support-notice) for more details.
+
 1.12.3 (August 14, 2020)
 =======================
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -594,6 +594,14 @@ class Device extends EventEmitter {
    * @param [options]
    */
   setup(token: string, options: Device.Options = { }): this {
+    if (isLegacyEdge()) {
+      throw new NotSupportedError(
+        'Microsoft Edge Legacy (https://support.microsoft.com/en-us/help/4533505/what-is-microsoft-edge-legacy) ' +
+        'is deprecated and will not be able to connect to Twilio to make or receive calls after September 1st, 2020. ' +
+        'Please see this documentation for a list of supported browsers ' +
+        'https://www.twilio.com/docs/voice/client/javascript#supported-browsers',
+      );
+    }
     if (!Device.isSupported && !options.ignoreBrowserSupport) {
       if (window && window.location && window.location.protocol === 'http:') {
         throw new NotSupportedError(`twilio.js wasn't able to find WebRTC browser support. \
@@ -601,19 +609,11 @@ class Device extends EventEmitter {
           which does not support WebRTC in many browsers. Please load this page over https and \
           try again.`);
       }
-      throw new NotSupportedError(`twilio.js 1.3+ SDKs require WebRTC/ORTC browser support. \
+
+      throw new NotSupportedError(`twilio.js 1.3+ SDKs require WebRTC browser support. \
         For more information, see <https://www.twilio.com/docs/api/client/twilio-js>. \
         If you have any questions about this announcement, please contact \
         Twilio Support at <help@twilio.com>.`);
-    }
-
-    if (isLegacyEdge()) {
-      this._log.warn(
-        'Microsoft Edge Legacy (https://support.microsoft.com/en-us/help/4533505/what-is-microsoft-edge-legacy) ' +
-        'is deprecated and will not be able to connect to Twilio to make or receive calls after September 1st, 2020. ' +
-        'Please see this documentation for a list of supported browsers ' +
-        'https://www.twilio.com/docs/voice/client/javascript#supported-browsers',
-      );
     }
 
     if (!token) {

--- a/lib/twilio/rtc/rtcpc.js
+++ b/lib/twilio/rtc/rtcpc.js
@@ -121,6 +121,8 @@ RTCPC.prototype.processAnswer = function(codecPreferences, sdp, onSuccess, onErr
 
        typeof (new mozRTCPeerConnection()).getLocalStreams === 'function'
 
+
+    NOTE(rrowland): We no longer support Legacy Edge as of Sep 1, 2020.
 */
 RTCPC.test = () => {
   if (typeof navigator === 'object') {
@@ -128,6 +130,10 @@ RTCPC.test = () => {
       || navigator.webkitGetUserMedia
       || navigator.mozGetUserMedia
       || navigator.getUserMedia;
+
+    if (util.isLegacyEdge(navigator)) {
+      return false;
+    }
 
     if (getUserMedia && typeof window.RTCPeerConnection === 'function') {
       return true;

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -209,10 +209,22 @@ describe('Device', function() {
         before(() => Promise.resolve((window as any).RTCPeerConnection = null));
 
         it('should throw an exception if not supported', () => {
-          assert.throws(() => device.setup(token, setupOptions), /require WebRTC\/ORTC browser support/);
+          assert.throws(() => device.setup(token, setupOptions), /require WebRTC browser support/);
         });
 
         after(() => (window as any).RTCPeerConnection = original);
+      });
+
+      context('when legacy edge', () => {
+        const original: any = (window as any).navigator;
+
+        before(() => Promise.resolve((window as any).navigator = { userAgent: 'foo edge/123 bar' }));
+
+        it('should throw an exception if not supported', () => {
+          assert.throws(() => device.setup(token, setupOptions), /Microsoft Edge Legacy/);
+        });
+
+        after(() => (window as any).navigator = original);
       });
 
       context('when supported', () => {


### PR DESCRIPTION
##  Pull Request Details

### JIRA link(s):

- [CLIENT-8023](https://issues.corp.twilio.com/browse/CLIENT-8023)

### Description

Replaces Edge Legacy warning with a thrown error.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
