### PR TITLE
CLIENT-7633 | Call destroy on unload and pagehide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.12.5 (In progress)
+====================
+
+Bug Fixes
+---------
+
+* Fixed an issue introduced in Safari 13.1 that caused calls to continue playing after navigating away from the page.
+
 1.12.4 (Sept 4, 2020)
 ====================
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -470,7 +470,7 @@ class Device extends EventEmitter {
   /**
    * Destroy the {@link Device}, freeing references to be garbage collected.
    */
-  destroy(): void {
+  destroy = (): void => {
     this._disconnectAll();
     this._stopRegistrationTimer();
 
@@ -489,7 +489,8 @@ class Device extends EventEmitter {
 
     if (typeof window !== 'undefined' && window.removeEventListener) {
       window.removeEventListener('beforeunload', this._confirmClose);
-      window.removeEventListener('unload', this._disconnectAll);
+      window.removeEventListener('unload', this.destroy);
+      window.removeEventListener('pagehide', this.destroy);
     }
   }
 
@@ -769,7 +770,8 @@ class Device extends EventEmitter {
 
     // Setup close protection and make sure we clean up ongoing calls on unload.
     if (typeof window !== 'undefined' && window.addEventListener) {
-      window.addEventListener('unload', this._disconnectAll);
+      window.addEventListener('unload', this.destroy);
+      window.addEventListener('pagehide', this.destroy);
       if (this.options.closeProtection) {
         window.addEventListener('beforeunload', this._confirmClose);
       }

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,5 +1,14 @@
 const root = global as any;
-root.window = { navigator: { userAgent: '' }, removeEventListener: () => { }, addEventListener: () => { } };
+let handlers = {};
+root.resetEvents = () => { handlers = {}; };
+root.window = {
+  navigator: { userAgent: '' },
+  removeEventListener: (name: string) => {delete (handlers as any)[name];},
+  addEventListener: (name:string, func: Function) => {(handlers as any)[name] = func;},
+  dispatchEvent: (name: string) => {
+    (handlers as any)[name]();
+  }
+};
 
 root.XMLHttpRequest = () => { };
 root.XMLHttpRequest.prototype.addEventListener = (name: string, cb: Function) => {

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -52,6 +52,7 @@ describe('Device', function() {
 
   afterEach(() => {
     clock.restore();
+    root.resetEvents();
   });
 
   beforeEach(() => {
@@ -870,6 +871,24 @@ describe('Device', function() {
         pstream.emit('ready');
         sinon.assert.calledOnce(device.emit as any);
         sinon.assert.calledWith(device.emit as any, 'ready');
+      });
+    });
+
+    describe('on unload or pagehide', () => {
+      beforeEach(() => {
+        device = new Device();
+      });
+      it('should call destroy once on pagehide', () => {
+        device.destroy = sinon.spy();
+        device.setup(token, setupOptions);
+        root.window.dispatchEvent('pagehide');
+        sinon.assert.calledOnce(device.destroy as any);
+      });
+      it('should call destroy once on unload', () => {
+        device.destroy = sinon.spy();
+        device.setup(token, setupOptions);
+        root.window.dispatchEvent('unload');
+        sinon.assert.calledOnce(device.destroy as any);
       });
     });
 


### PR DESCRIPTION
This is intended to address. https://github.com/twilio/twilio-client.js/issues/164

## Pull Request Details

### JIRA link(s):

- [CLIENT-7633](https://issues.corp.twilio.com/browse/CLIENT-7633)

### Description

This PR updated our navigation behavior to call destroy (rather than just disconnectAll) and does the same for both the `unload` and `pagehide` events.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
