### PR TITLE
CLIENT-7980 | Disconnect sound plays after connection.ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.12.5 (In Progress)
+====================
+
+Bug Fixes
+---------
+
+* Fixed an issue where the disconnect sound plays after the caller cancelled the incoming call.
+
 1.12.4 (Sept 4, 2020)
 ====================
 

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -452,7 +452,11 @@ class Connection extends EventEmitter {
 
     this.mediaStream.onclose = () => {
       this._status = Connection.State.Closed;
-      if (this.options.shouldPlayDisconnect && this.options.shouldPlayDisconnect()) {
+      if (this.options.shouldPlayDisconnect && this.options.shouldPlayDisconnect()
+        // Don't play disconnect sound if this was from a cancel event. i.e. the call
+        // was ignored or hung up even before it was answered.
+        && !this._isCancelled) {
+
         this._soundcache.get(Device.SoundName.Disconnect).play();
       }
 

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -1397,7 +1397,7 @@ describe('Connection', function() {
       let closeStub: any;
       let publishStub: any;
 
-      beforeEach(() => {
+      const initConnection = () => {
         cleanupStub = sinon.stub();
         closeStub = sinon.stub();
         publishStub = sinon.stub();
@@ -1414,7 +1414,9 @@ describe('Connection', function() {
         conn._publisher = {
           info: publishStub
         };
-      });
+      };
+
+      beforeEach(initConnection);
 
       context('when the callsid matches', () => {
         it('should transition to closed', () => {
@@ -1441,6 +1443,17 @@ describe('Connection', function() {
           pstream.emit('cancel', { callsid: 'CA123' });
 
           return wait().then(() => sinon.assert.notCalled(callback));
+        });
+
+        it('should not play disconnect sound', () => {
+          options.shouldPlayDisconnect = () => true;
+          initConnection();
+          conn.mediaStream.close = () => mediaStream.onclose();
+          pstream.emit('cancel', { callsid: 'CA123' });
+
+          return wait().then(() => {
+            sinon.assert.notCalled(soundcache.get(Device.SoundName.Disconnect).play);
+          });
         });
       });
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7980](https://issues.corp.twilio.com/browse/CLIENT-7980)

### Description

Fixed an issue where the disconnect sound plays after the caller cancelled the incoming call.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
