### PR TITLE
Open stream after listeners are added

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1227,6 +1227,7 @@ class Device extends EventEmitter {
     this.stream.addListener('invite', this._onSignalingInvite);
     this.stream.addListener('offline', this._onSignalingOffline);
     this.stream.addListener('ready', this._onSignalingReady);
+    this.stream.open();
   }
 
   /**

--- a/lib/twilio/pstream.js
+++ b/lib/twilio/pstream.js
@@ -100,12 +100,15 @@ function PStream(token, uris, options) {
   this.transport.on('error', this._handleTransportError);
   this.transport.on('message', this._handleTransportMessage);
   this.transport.on('open', this._handleTransportOpen);
-  this.transport.open();
 
   return this;
 }
 
 util.inherits(PStream, EventEmitter);
+
+PStream.prototype.open = function() {
+  this.transport.open();
+};
 
 PStream.prototype._handleTransportClose = function() {
   this.emit('transportClose');

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -529,14 +529,25 @@ describe('Device', function() {
       let device: any;
       let options: any;
       let pStreamFactory: any;
+      let pStream: any;
 
       beforeEach(() => {
-        pStreamFactory = sinon.stub().returns({
-          addListener: sinon.stub()
-        });
+        pStream = {
+          addListener: sinon.stub(),
+          open: sinon.stub()
+        };
+        pStreamFactory = sinon.stub().returns(pStream);
 
         device = new Device();
         options = Object.assign({}, setupOptions, { pStreamFactory });
+      });
+
+      it('opens stream after listeners are added', () => {
+        device.setup(token, options);
+        sinon.assert.callOrder(
+          pStream.addListener,
+          pStream.open
+        );
       });
 
       it('should call updateToken with the passed token', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

Currently `error` listener is added after the connection is open.
So if there is a synchronous error during connection open (for example
exeption) then we don't receive this error in the error listener.

We found this after noticing that if websocket connection to Twilio is
blocked by CSP then on iOS Safari it's not being reported as error.

On Chrome this does not reproduce as it will not throw an error in this
case, but instead call WebSocket error listener.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
