### PR TITLE
[CLIENT-7589] Add `max` threshold warning back to `packetsLostFraction`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Changes
 -------
 
-* The behavior for raising the `high-packet-loss` warning has been updated. Now, the most recent seven seconds of packet-loss samples are recorded and analyzed. If the average of these samples is greater than `3%` packet-loss, then the warning is raised. When the average packet-loss over the most recent seven seconds is less than or equal to `1%` packet-loss, then the warning is cleared.
+* Added `high-packets-lost-fraction` [network warning](https://www.twilio.com/docs/voice/insights/call-quality-events-twilio-client-sdk#network-warnings). This new warning is raised when the average of the most recent seven seconds of packet-loss samples is greater than `3%`. When the average packet-loss over the most recent seven seconds is less than or equal to `1%`, then the warning is cleared.
 * The behavior for raising the `constant-audio-level` warning has been updated. Now, the most recent ten seconds of volume values are recorded and then analyzed. If the standard deviation of these samples is less than 1% of the maximum audio value, then the warning is raised. When the standard deviation is greater than 1% and the warning has already been raised, then the warning is cleared.
 
 1.12.5 (Sept 22, 2020)

--- a/lib/twilio/statsMonitor.ts
+++ b/lib/twilio/statsMonitor.ts
@@ -562,9 +562,9 @@ class StatsMonitor extends EventEmitter {
           const avg: number = average(values);
 
           if (comparator(avg, limit[thresholdName])) {
-            this._raiseWarning(statName, thresholdName, { value: avg });
+            this._raiseWarning(statName, thresholdName, { values, samples: relevantSamples });
           } else if (!comparator(avg, limit.clearValue || limit[thresholdName])) {
-            this._clearWarning(statName, thresholdName, { value: avg });
+            this._clearWarning(statName, thresholdName, { values, samples: relevantSamples });
           }
         }
       });

--- a/lib/twilio/statsMonitor.ts
+++ b/lib/twilio/statsMonitor.ts
@@ -30,11 +30,13 @@ const DEFAULT_THRESHOLDS: StatsMonitor.ThresholdOptions = {
   bytesSent: { clearCount: 2, min: 1, raiseCount: 3, sampleCount: 3 },
   jitter: { max: 30 },
   mos: { min: 3 },
-  packetsLostFraction: {
+  packetsLostFraction: [{
+    max: 1,
+  }, {
     clearValue: 1,
     maxAverage: 3,
     sampleCount: 7,
-  },
+  }],
   rtt: { max: 400 },
 };
 
@@ -432,12 +434,26 @@ class StatsMonitor extends EventEmitter {
     if (this._activeWarnings.has(warningId)) { return; }
     this._activeWarnings.set(warningId, { timeRaised: Date.now() });
 
+    const thresholds: StatsMonitor.ThresholdOption | StatsMonitor.ThresholdOption[] =
+      this._thresholds[statName];
+
+    let thresholdValue;
+
+    if (Array.isArray(thresholds)) {
+      const foundThreshold = thresholds.find(threshold => thresholdName in threshold);
+      if (foundThreshold) {
+        thresholdValue = foundThreshold[thresholdName as keyof StatsMonitor.ThresholdOption];
+      }
+    } else {
+      thresholdValue = this._thresholds[statName][thresholdName];
+    }
+
     this.emit('warning', {
       ...data,
       name: statName,
       threshold: {
         name: thresholdName,
-        value: this._thresholds[statName][thresholdName],
+        value: thresholdValue,
       },
     });
   }
@@ -457,95 +473,101 @@ class StatsMonitor extends EventEmitter {
    * @param statName - Name of the stat to compare.
    */
   private _raiseWarningsForStat(statName: string): void {
-    const samples = this._sampleBuffer;
-    const limits = this._thresholds[statName];
+    const limits: StatsMonitor.ThresholdOptions[] =
+      Array.isArray(this._thresholds[statName])
+        ? this._thresholds[statName]
+        : [this._thresholds[statName]];
 
-    const clearCount = limits.clearCount || SAMPLE_COUNT_CLEAR;
-    const raiseCount = limits.raiseCount || SAMPLE_COUNT_RAISE;
-    const sampleCount = limits.sampleCount || this._maxSampleCount;
+    limits.forEach((limit: StatsMonitor.ThresholdOptions) => {
+      const samples = this._sampleBuffer;
 
-    let relevantSamples = samples.slice(-sampleCount);
-    const values = relevantSamples.map(sample => sample[statName]);
+      const clearCount = limit.clearCount || SAMPLE_COUNT_CLEAR;
+      const raiseCount = limit.raiseCount || SAMPLE_COUNT_RAISE;
+      const sampleCount = limit.sampleCount || this._maxSampleCount;
 
-    // (rrowland) If we have a bad or missing value in the set, we don't
-    // have enough information to throw or clear a warning. Bail out.
-    const containsNull = values.some(value => typeof value === 'undefined' || value === null);
+      let relevantSamples = samples.slice(-sampleCount);
+      const values = relevantSamples.map(sample => sample[statName]);
 
-    if (containsNull) {
-      return;
-    }
+      // (rrowland) If we have a bad or missing value in the set, we don't
+      // have enough information to throw or clear a warning. Bail out.
+      const containsNull = values.some(value => typeof value === 'undefined' || value === null);
 
-    let count;
-    if (typeof limits.max === 'number') {
-      count = countHigh(limits.max, values);
-      if (count >= raiseCount) {
-        this._raiseWarning(statName, 'max', { values, samples: relevantSamples });
-      } else if (count <= clearCount) {
-        this._clearWarning(statName, 'max', { values, samples: relevantSamples });
-      }
-    }
-
-    if (typeof limits.min === 'number') {
-      count = countLow(limits.min, values);
-      if (count >= raiseCount) {
-        this._raiseWarning(statName, 'min', { values, samples: relevantSamples });
-      } else if (count <= clearCount) {
-        this._clearWarning(statName, 'min', { values, samples: relevantSamples });
-      }
-    }
-
-    if (typeof limits.maxDuration === 'number' && samples.length > 1) {
-      relevantSamples = samples.slice(-2);
-      const prevValue = relevantSamples[0][statName];
-      const curValue = relevantSamples[1][statName];
-
-      const prevStreak = this._currentStreaks.get(statName) || 0;
-      const streak = (prevValue === curValue) ? prevStreak + 1 : 0;
-
-      this._currentStreaks.set(statName, streak);
-
-      if (streak >= limits.maxDuration) {
-        this._raiseWarning(statName, 'maxDuration', { value: streak });
-      } else if (streak === 0) {
-        this._clearWarning(statName, 'maxDuration', { value: prevStreak });
-      }
-    }
-
-    if (typeof limits.minStandardDeviation === 'number') {
-      const sampleSets: number[][] = this._supplementalSampleBuffers[statName];
-      if (!sampleSets || sampleSets.length < limits.sampleCount) {
-        return;
-      }
-      if (sampleSets.length > limits.sampleCount) {
-        sampleSets.splice(0, sampleSets.length - limits.sampleCount);
-      }
-      const flatSamples: number[] = flattenSamples(sampleSets.slice(-sampleCount));
-      const stdDev: number | null = calculateStandardDeviation(flatSamples);
-
-      if (typeof stdDev !== 'number') {
+      if (containsNull) {
         return;
       }
 
-      if (stdDev < limits.minStandardDeviation) {
-        this._raiseWarning(statName, 'minStandardDeviation', { value: stdDev });
-      } else {
-        this._clearWarning(statName, 'minStandardDeviation', { value: stdDev });
-      }
-    }
-
-    ([
-      ['maxAverage', (x: number, y: number) => x > y],
-      ['minAverage', (x: number, y: number) => x < y],
-    ] as const).forEach(([thresholdName, comparator]) => {
-      if (typeof limits[thresholdName] === 'number' && values.length > 0) {
-        const avg: number = average(values);
-
-        if (comparator(avg, limits[thresholdName])) {
-          this._raiseWarning(statName, thresholdName, { value: avg });
-        } else if (!comparator(avg, limits.clearValue || limits[thresholdName])) {
-          this._clearWarning(statName, thresholdName, { value: avg });
+      let count;
+      if (typeof limit.max === 'number') {
+        count = countHigh(limit.max, values);
+        if (count >= raiseCount) {
+          this._raiseWarning(statName, 'max', { values, samples: relevantSamples });
+        } else if (count <= clearCount) {
+          this._clearWarning(statName, 'max', { values, samples: relevantSamples });
         }
       }
+
+      if (typeof limit.min === 'number') {
+        count = countLow(limit.min, values);
+        if (count >= raiseCount) {
+          this._raiseWarning(statName, 'min', { values, samples: relevantSamples });
+        } else if (count <= clearCount) {
+          this._clearWarning(statName, 'min', { values, samples: relevantSamples });
+        }
+      }
+
+      if (typeof limit.maxDuration === 'number' && samples.length > 1) {
+        relevantSamples = samples.slice(-2);
+        const prevValue = relevantSamples[0][statName];
+        const curValue = relevantSamples[1][statName];
+
+        const prevStreak = this._currentStreaks.get(statName) || 0;
+        const streak = (prevValue === curValue) ? prevStreak + 1 : 0;
+
+        this._currentStreaks.set(statName, streak);
+
+        if (streak >= limit.maxDuration) {
+          this._raiseWarning(statName, 'maxDuration', { value: streak });
+        } else if (streak === 0) {
+          this._clearWarning(statName, 'maxDuration', { value: prevStreak });
+        }
+      }
+
+      if (typeof limit.minStandardDeviation === 'number') {
+        const sampleSets: number[][] = this._supplementalSampleBuffers[statName];
+        if (!sampleSets || sampleSets.length < limit.sampleCount) {
+          return;
+        }
+        if (sampleSets.length > limit.sampleCount) {
+          sampleSets.splice(0, sampleSets.length - limit.sampleCount);
+        }
+        const flatSamples: number[] = flattenSamples(sampleSets.slice(-sampleCount));
+        const stdDev: number | null = calculateStandardDeviation(flatSamples);
+
+        if (typeof stdDev !== 'number') {
+          return;
+        }
+
+        if (stdDev < limit.minStandardDeviation) {
+          this._raiseWarning(statName, 'minStandardDeviation', { value: stdDev });
+        } else {
+          this._clearWarning(statName, 'minStandardDeviation', { value: stdDev });
+        }
+      }
+
+      ([
+        ['maxAverage', (x: number, y: number) => x > y],
+        ['minAverage', (x: number, y: number) => x < y],
+      ] as const).forEach(([thresholdName, comparator]) => {
+        if (typeof limit[thresholdName] === 'number' && values.length > 0) {
+          const avg: number = average(values);
+
+          if (comparator(avg, limit[thresholdName])) {
+            this._raiseWarning(statName, thresholdName, { value: avg });
+          } else if (!comparator(avg, limit.clearValue || limit[thresholdName])) {
+            this._clearWarning(statName, thresholdName, { value: avg });
+          }
+        }
+      });
     });
   }
 }
@@ -675,7 +697,7 @@ namespace StatsMonitor {
     /**
      * Rules to apply to sample.packetsLostFraction
      */
-    packetsLostFraction?: ThresholdOption;
+    packetsLostFraction?: ThresholdOption[];
 
     /**
      * Rules to apply to sample.rtt

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -1735,17 +1735,61 @@ describe('Connection', function() {
   });
 
   describe('on monitor.warning', () => {
-    it('should properly translate `maxAverage`', () => {
-      monitor.emit('warning', {
-        name: 'packetsLostFraction',
-        threshold: { name: 'maxAverage', value: 3 },
-        value: 1,
+    context('single-threshold warnings', () => {
+      it('should properly translate `maxAverage`', () => {
+        monitor.emit('warning', {
+          name: 'jitter',
+          threshold: { name: 'maxAverage', value: 1 },
+          value: 3,
+        });
+        sinon.assert.calledOnce(publisher.post);
+        const [warningStr, warningType, warning] = publisher.post.args[0];
+        assert.equal(warningStr, 'warning');
+        assert.equal(warningType, 'network-quality-warning-raised');
+        assert.equal(warning, 'high-jitter');
       });
-      sinon.assert.calledOnce(publisher.post);
-      const [warningStr, warningType, warning] = publisher.post.args[0];
-      assert.equal(warningStr, 'warning');
-      assert.equal(warningType, 'network-quality-warning-raised');
-      assert.equal(warning, 'high-packet-loss');
+
+      it('should properly translate `max`', () => {
+        monitor.emit('warning', {
+          name: 'jitter',
+          samples: [],
+          threshold: { name: 'max', value: 1 },
+          values: [3, 3, 3],
+        });
+        sinon.assert.calledOnce(publisher.post);
+        const [warningStr, warningType, warning] = publisher.post.args[0];
+        assert.equal(warningStr, 'warning');
+        assert.equal(warningType, 'network-quality-warning-raised');
+        assert.equal(warning, 'high-jitter');
+      });
+    });
+
+    context('multiple-threshold warnings', () => {
+      it('should properly translate `maxAverage`', () => {
+        monitor.emit('warning', {
+          name: 'packetsLostFraction',
+          threshold: { name: 'maxAverage', value: 3 },
+          value: 1,
+        });
+        sinon.assert.calledOnce(publisher.post);
+        const [warningStr, warningType, warning] = publisher.post.args[0];
+        assert.equal(warningStr, 'warning');
+        assert.equal(warningType, 'network-quality-warning-raised');
+        assert.equal(warning, 'high-packets-lost-fraction');
+      });
+
+      it('should properly translate `max`', () => {
+        monitor.emit('warning', {
+          name: 'packetsLostFraction',
+          threshold: { name: 'max', value: 1 },
+          values: [2, 2, 2],
+        });
+        sinon.assert.calledOnce(publisher.post);
+        const [warningStr, warningType, warning] = publisher.post.args[0];
+        assert.equal(warningStr, 'warning');
+        assert.equal(warningType, 'network-quality-warning-raised');
+        assert.equal(warning, 'high-packet-loss');
+      });
     });
 
     it('should properly translate `minStandardDeviation`', () => {

--- a/tests/unit/statsMonitor.ts
+++ b/tests/unit/statsMonitor.ts
@@ -446,15 +446,12 @@ describe('StatsMonitor', () => {
           clock.restore();
 
           await wait().then(() => {
+            const data = onWarning.args[0][0];
             sinon.assert.calledOnce(onWarning);
-            assert.deepEqual(onWarning.args[0][0], {
-              name: STAT_NAME,
-              threshold: {
-                name: 'maxAverage',
-                value: 3,
-              },
-              value: 5,
-            });
+            assert.equal(data.name, STAT_NAME);
+            assert.deepEqual(data.threshold, { name: 'maxAverage', value: 3 });
+            assert.deepEqual(data.values, [0, 10]);
+            assert(!!data.samples);
           });
         });
 
@@ -491,16 +488,13 @@ describe('StatsMonitor', () => {
           clock.restore();
 
           await wait().then(() => {
+            const data = onWarning.args[0][0];
             sinon.assert.calledOnce(onWarning);
-            assert.deepEqual(onWarning.args[0][0], {
-              name: STAT_NAME,
-              threshold: {
-                name: 'maxAverage',
-                value: 3,
-              },
-              value: 5,
-            });
             sinon.assert.calledOnce(onWarningCleared);
+            assert.equal(data.name, STAT_NAME);
+            assert.deepEqual(data.threshold, { name: 'maxAverage', value: 3 });
+            assert.deepEqual(data.values, [0, 10]);
+            assert(!!data.samples);
           });
         });
       });
@@ -583,14 +577,11 @@ describe('StatsMonitor', () => {
         await wait().then(() => {
           sinon.assert.callCount(onWarning, 2);
 
-          assert.deepEqual(onWarning.args[0][0], {
-            name: STAT_NAME,
-            threshold: {
-              name: 'maxAverage',
-              value: 3,
-            },
-            value: 5,
-          });
+          const data = onWarning.args[0][0];
+          assert.equal(data.name, STAT_NAME);
+          assert.deepEqual(data.threshold, { name: 'maxAverage', value: 3 });
+          assert.deepEqual(data.values, [5]);
+          assert(!!data.samples);
 
           assert.deepEqual({
             ...onWarning.args[1][0],

--- a/tests/unit/statsMonitor.ts
+++ b/tests/unit/statsMonitor.ts
@@ -505,6 +505,108 @@ describe('StatsMonitor', () => {
         });
       });
     });
+
+    context('multiple thresholds', () => {
+      it('should raise the appropriate warning if reached', async () => {
+        const onWarning = sinon.stub();
+
+        const mockRTCStats = {
+          [STAT_NAME]: 2,
+        };
+
+        const statsMonitor = new StatsMonitor({
+          getRTCStats: async () => mockRTCStats,
+          thresholds: {
+            [STAT_NAME]: [{
+              max: 1,
+            }, {
+              clearValue: 1,
+              maxAverage: 3,
+              sampleCount: 7,
+            }],
+          } as any,
+        });
+
+        statsMonitor.on('warning', onWarning);
+
+        statsMonitor.enable({});
+
+        await clock.tickAsync(10000);
+
+        clock.restore();
+
+        await wait().then(() => {
+          sinon.assert.calledOnce(onWarning);
+          assert.deepEqual({
+            ...onWarning.args[0][0],
+            samples: null,
+          }, {
+            name: STAT_NAME,
+            samples: null,
+            threshold: {
+              name: 'max',
+              value: 1,
+            },
+            values: [2, 2, 2],
+          });
+        });
+      });
+
+      it('should raise all warnings when reached', async () => {
+        const onWarning = sinon.stub();
+
+        const mockRTCStats = {
+          [STAT_NAME]: 5,
+        };
+
+        const statsMonitor = new StatsMonitor({
+          getRTCStats: async () => mockRTCStats,
+          thresholds: {
+            [STAT_NAME]: [{
+              max: 1,
+            }, {
+              clearValue: 1,
+              maxAverage: 3,
+              sampleCount: 7,
+            }],
+          } as any,
+        });
+
+        statsMonitor.on('warning', onWarning);
+
+        statsMonitor.enable({});
+
+        await clock.tickAsync(10000);
+
+        clock.restore();
+
+        await wait().then(() => {
+          sinon.assert.callCount(onWarning, 2);
+
+          assert.deepEqual(onWarning.args[0][0], {
+            name: STAT_NAME,
+            threshold: {
+              name: 'maxAverage',
+              value: 3,
+            },
+            value: 5,
+          });
+
+          assert.deepEqual({
+            ...onWarning.args[1][0],
+            samples: null,
+          }, {
+            name: STAT_NAME,
+            samples: null,
+            threshold: {
+              name: 'max',
+              value: 1,
+            },
+            values: [5, 5, 5],
+          });
+        });
+      });
+    });
   });
 
   describe(`StatsMonitor on 'error'`, () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7589](https://issues.corp.twilio.com/browse/CLIENT-7589)

### Description

Re-adds the original `max` threshold warning back to `packetsLostFraction` within `statsMonitor`. Now, both `max` and `maxAverage` thresholds are used.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
