### PR TITLE
CLIENT-8168 | Adding preflight boolean to signaling invite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changes
 
 * We now log an `outgoing` event to Insights when making an outbound call. This event also contains information whether the call is a preflight or not.
 
+* Added a boolean field to the signaling payload for calls initiated by `Device.testPreflight` for debugging purposes.
+
 1.13.0-beta2 (Sept 10, 2020)
 ============================
 

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -322,6 +322,7 @@ class Connection extends EventEmitter {
         forceAggressiveIceNomination: this.options.forceAggressiveIceNomination,
         isUnifiedPlan: this._isUnifiedPlanDefault,
         maxAverageBitrate: this.options.maxAverageBitrate,
+        preflight: this.options.preflight,
       });
 
     this.on('volume', (inputVolume: number, outputVolume: number): void => {

--- a/lib/twilio/pstream.js
+++ b/lib/twilio/pstream.js
@@ -179,10 +179,11 @@ PStream.prototype.register = function(mediaCapabilities) {
   this._publish('register', regPayload, true);
 };
 
-PStream.prototype.invite = function(sdp, callsid, params) {
+PStream.prototype.invite = function(sdp, callsid, preflight, params) {
   const payload = {
     callsid,
     sdp,
+    preflight: !!preflight,
     twilio: params ? { params } : {}
   };
   this._publish('invite', payload, true);

--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -892,7 +892,7 @@ PeerConnection.prototype.makeOutgoingCall = function(token, params, callsid, rtc
 
   function onOfferSuccess() {
     if (self.status !== 'closed') {
-      self.pstream.invite(self.version.getSDP(), self.callSid, params);
+      self.pstream.invite(self.version.getSDP(), self.callSid, self.options.preflight, params);
       self._setupRTCDtlsTransportListener();
     }
   }

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -812,7 +812,7 @@ describe('PeerConnection', () => {
         version,
         status: CLOSED,
         onerror: sinon.stub(),
-        options: { },
+        options: { preflight: true },
         pstream: {
           once: sinon.stub(),
           on: sinon.stub(),
@@ -871,7 +871,7 @@ describe('PeerConnection', () => {
       assert(version.createOffer.calledWithExactly(undefined, undefined, {audio: true}, sinon.match.func, sinon.match.func));
       assert.equal(callback.called, false);
       assert(context.pstream.invite.calledOnce);
-      assert(context.pstream.invite.calledWithExactly(eSDP, eCallSid, eParams));
+      assert(context.pstream.invite.calledWithExactly(eSDP, eCallSid, true, eParams));
       assert(version.getSDP.calledOnce);
       assert(version.getSDP.calledWithExactly());
       assert(context.pstream.on.calledWithExactly('answer', sinon.match.func));
@@ -888,7 +888,7 @@ describe('PeerConnection', () => {
       assert(version.createOffer.calledWithExactly(undefined, undefined, {audio: true}, sinon.match.func, sinon.match.func));
       assert.equal(callback.called, false);
       assert(context.pstream.invite.calledOnce);
-      assert(context.pstream.invite.calledWithExactly(eSDP, eCallSid, eParams));
+      assert(context.pstream.invite.calledWithExactly(eSDP, eCallSid, true, eParams));
       assert(version.getSDP.calledOnce);
       assert(version.getSDP.calledWithExactly());
       assert(context.pstream.on.calledWithExactly('answer', sinon.match.func));

--- a/tests/pstream.js
+++ b/tests/pstream.js
@@ -257,14 +257,19 @@ describe('PStream', () => {
     ]],
     ['invite', [
       {
-        args: ['bar', 'foo', ''],
-        payload: { callsid: 'foo', sdp: 'bar', twilio: {} },
+        args: ['bar', 'foo', true, ''],
+        payload: { callsid: 'foo', sdp: 'bar', preflight: true, twilio: {} },
         scenario: 'called with empty params'
       },
       {
-        args: ['bar', 'foo', 'baz=zee&foo=2'],
-        payload: { callsid: 'foo', sdp: 'bar', twilio: { params: 'baz=zee&foo=2' } },
+        args: ['bar', 'foo', true, 'baz=zee&foo=2'],
+        payload: { callsid: 'foo', sdp: 'bar', preflight: true,  twilio: { params: 'baz=zee&foo=2' } },
         scenario: 'called with non-empty params'
+      },
+      {
+        args: ['bar', 'foo', false, ''],
+        payload: { callsid: 'foo', sdp: 'bar', preflight: false,  twilio: {} },
+        scenario: 'called with preflight = false'
       }
     ]],
     ['answer', [


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-8168](https://issues.corp.twilio.com/browse/CLIENT-8168)

### Description

Adding preflight boolean to signaling invite

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
