### PR TITLE
1.13.0 changelog and rename testPreflight to runPreflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 1.13.0 (In Progress)
 ====================
 
+1.13.0-beta2 has been promoted to 1.13.0 GA. Here's what's new in 1.13.0.
+
+New Features
+------------
+
+### Voice diagnostics using PreflightTest API
+
+The SDK now supports a preflight test API which can help determine Voice calling readiness. The API creates a test call and will provide information to help troubleshoot call related issues. This new API is a static member of the [Device](https://www.twilio.com/docs/voice/client/javascript/device#twilio-device) class and can be used like the example below. Please see [Device.testPreflight](https://www.twilio.com/docs/voice/client/javascript/device#testpreflight) method and [PreflightTest](https://www.twilio.com/docs/voice/client/javascript/preflighttest) class for more details about this new API.
+
+```js
+// Initiate the test
+const preflight = Device.testPreflight(token, options);
+
+// Subscribe to events
+preflight.on('completed', (report) => console.log(report));
+preflight.on('failed', (error) => console.log(error));
+```
+
 Changes
 -------
+
+* [Connection.on('warning')](https://www.twilio.com/docs/voice/client/javascript/connection#onwarning-handlerwarningname) now provides data associated with the warning. This data can provide more details about the warning such as thresholds and WebRTC samples collected that caused the warning. The example below is a warning for high jitter. Please see [Voice Insights SDK Events Reference](https://www.twilio.com/docs/voice/insights/call-quality-events-twilio-client-sdk#warning-events) for a list of possible warnings.
 
 * Added `high-packets-lost-fraction` [network warning](https://www.twilio.com/docs/voice/insights/call-quality-events-twilio-client-sdk#network-warnings). This new warning is raised when the average of the most recent seven seconds of packet-loss samples is greater than `3%`. When the average packet-loss over the most recent seven seconds is less than or equal to `1%`, then the warning is cleared.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,10 @@ New Features
 
 ### Voice diagnostics using PreflightTest API
 
-The SDK now supports a preflight test API which can help determine Voice calling readiness. The API creates a test call and will provide information to help troubleshoot call related issues. This new API is a static member of the [Device](https://www.twilio.com/docs/voice/client/javascript/device#twilio-device) class and can be used like the example below. Please see [Device.testPreflight](https://www.twilio.com/docs/voice/client/javascript/device#testpreflight) method and [PreflightTest](https://www.twilio.com/docs/voice/client/javascript/preflighttest) class for more details about this new API.
+The SDK now supports a preflight test API which can help determine Voice calling readiness. The API creates a test call and will provide information to help troubleshoot call related issues. Please see the following for more details.
 
-```js
-// Initiate the test
-const preflight = Device.testPreflight(token, options);
-
-// Subscribe to events
-preflight.on('completed', (report) => console.log(report));
-preflight.on('failed', (error) => console.log(error));
-```
+* [API Docs](https://www.twilio.com/docs/voice/client/javascript/preflighttest)
+* [Quick deploy App](https://github.com/twilio/rtc-diagnostics-react-app)
 
 Changes
 -------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Changes
 
 * We now log an `outgoing` event to Insights when making an outbound call. This event also contains information whether the call is a preflight or not.
 
-* Added a boolean field to the signaling payload for calls initiated by `Device.testPreflight` for debugging purposes.
+* Added a boolean field to the signaling payload for calls initiated by `Device.runPreflight` for debugging purposes.
 
 1.13.0-beta2 (Sept 10, 2020)
 ============================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 1.13.0 (In Progress)
 ====================
 
-1.13.0-beta2 has been promoted to 1.13.0 GA. Here's what's new in 1.13.0.
+1.13.0-beta2 has been promoted to 1.13.0 GA. Here's a summary of what is new in 1.13.0.
 
 New Features
 ------------
@@ -23,6 +23,43 @@ Changes
 -------
 
 * [Connection.on('warning')](https://www.twilio.com/docs/voice/client/javascript/connection#onwarning-handlerwarningname) now provides data associated with the warning. This data can provide more details about the warning such as thresholds and WebRTC samples collected that caused the warning. The example below is a warning for high jitter. Please see [Voice Insights SDK Events Reference](https://www.twilio.com/docs/voice/insights/call-quality-events-twilio-client-sdk#warning-events) for a list of possible warnings.
+
+  ```ts
+  connection.on('warning', (warningName, warningData) => {
+    console.log({ warningName, warningData });
+  });
+  ```
+
+  Example output:
+
+  ```js
+  {
+    "warningName": "high-jitter",
+    "warningData": {
+      "name": "jitter",
+
+      /**
+       *  Array of jitter values in the past 5 samples that triggered the warning
+       */
+      "values": [35, 44, 31, 32, 32],
+
+      /**
+       * Array of samples collected that triggered the warning.
+       * See sample object format here https://www.twilio.com/docs/voice/client/javascript/connection#sample
+       */
+      "samples": [...],
+
+      /**
+       * The threshold configuration.
+       * In this example, high-jitter warning will be raised if the value exceeded more than 30
+       */
+      "threshold": {
+        "name": "max",
+        "value": 30
+      }
+    }
+  }
+  ```
 
 * Added `high-packets-lost-fraction` [network warning](https://www.twilio.com/docs/voice/insights/call-quality-events-twilio-client-sdk#network-warnings). This new warning is raised when the average of the most recent seven seconds of packet-loss samples is greater than `3%`. When the average packet-loss over the most recent seven seconds is less than or equal to `1%`, then the warning is cleared.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 New Features
 ------------
 
-### Voice diagnostics using PreflightTest API
+### Voice diagnostics using runPreflight API
 
 The SDK now supports a preflight test API which can help determine Voice calling readiness. The API creates a test call and will provide information to help troubleshoot call related issues. Please see the following for more details.
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -216,7 +216,7 @@ class Device extends EventEmitter {
    * @param token - A Twilio JWT token string
    * @param options
    */
-  static testPreflight(token: string, options?: PreflightTest.Options): PreflightTest {
+  static runPreflight(token: string, options?: PreflightTest.Options): PreflightTest {
     return new PreflightTest(token, { audioContext: Device._getOrCreateAudioContext(), ...options });
   }
 

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -788,7 +788,7 @@ export namespace PreflightTest {
      * });
      *
      * // Use the TURN credentials using the iceServers parameter
-     * const preflightTest = Device.testPreflight(token, { iceServers });
+     * const preflightTest = Device.runPreflight(token, { iceServers });
      *
      * // Read from the report object to determine whether TURN is required to connect to media
      * preflightTest.on('completed', (report) => {
@@ -907,7 +907,7 @@ export namespace PreflightTest {
     samples: RTCSample[];
 
     /**
-     * The edge passed to `Device.testPreflight`.
+     * The edge passed to `Device.runPreflight`.
      */
     selectedEdge?: string;
 

--- a/tests/integration/preflight.ts
+++ b/tests/integration/preflight.ts
@@ -58,7 +58,7 @@ describe('Preflight Test', function() {
       receiverDevice.on('incoming', (conn: Connection) => {
         conn.accept();
       });
-      preflight = Device.testPreflight(callerToken);
+      preflight = Device.runPreflight(callerToken);
       callerDevice = preflight['_device'];
 
       (callerDevice as any).connectOverride = callerDevice.connect;
@@ -137,7 +137,7 @@ describe('Preflight Test', function() {
       receiverDevice.on('incoming', (conn: Connection) => {
         conn.accept();
       });
-      preflight = Device.testPreflight(callerToken, {
+      preflight = Device.runPreflight(callerToken, {
         codecPreferences: [Connection.Codec.PCMU],
       });
       callerDevice = preflight['_device'];
@@ -171,7 +171,7 @@ describe('Preflight Test', function() {
           receiverDevice.on('incoming', (conn: Connection) => {
             conn.accept();
           });
-          preflight = Device.testPreflight(callerToken, {
+          preflight = Device.runPreflight(callerToken, {
             edge: selectedEdge,
           });
           const waitForReport: Promise<PreflightTest.Report> =
@@ -208,7 +208,7 @@ describe('Preflight Test', function() {
       receiverDevice.on('incoming', (conn: Connection) => {
         conn.accept();
       });
-      preflight = Device.testPreflight(callerToken);
+      preflight = Device.runPreflight(callerToken);
       callerDevice = preflight['_device'];
 
       (callerDevice as any).connectOverride = callerDevice.connect;
@@ -259,7 +259,7 @@ describe('Preflight Test', function() {
           receiverDevice.on('incoming', (conn: Connection) => {
             conn.accept();
           });
-          preflight = Device.testPreflight(callerToken);
+          preflight = Device.runPreflight(callerToken);
           callerDevice = preflight['_device'];
 
           (callerDevice as any).connectOverride = callerDevice.connect;


### PR DESCRIPTION
Changelog for 1.13.0. I also added documentation to wagtail. See drafts below. They will be live once we get green light from QE.

PreflightTest class: https://www.twilio.com/docs/admin/pages/22197/view_draft/
Device.testPreflight: https://www.twilio.com/docs/admin/pages/1773/view_draft/#testpreflight
Connection.on('warning'): https://www.twilio.com/docs/admin/pages/1772/view_draft/#onwarning-handlerwarningname-warningdata

Edit: Also renamed testPreflight to runPreflight base on discussions.