### PR TITLE
[CLIENT-7730] Allow Connection specific ICE Servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
-1.13.1 (Jan 11, 2020)
+1.13.2 (In Progress)
 ====================
+
+New Features
+------------
+
+### Allow Connection specific ICE Servers
+
+Developers can now opt to override `rtcConfiguration` set within `Device.options` per specific outgoing and incoming `Connection`s.
+
+To use this feature, a new parameter `rtcConfiguration` can be passed to `Device.connect` and `Connection.accept`. The function signatures are now described as below.
+```ts
+Device.connect(params?: Record<string, string>,
+               audioConstraints?: MediaTrackConstraints | boolean,
+               rtcConfiguration?: RTCConfiguration);
+
+Connection.accept(audioConstraints?: MediaTrackConstraints | boolean,
+                  rtcConfiguration?: RTCConfiguration);
+```
+Passing the `rtcConfiguration` parameter to these functions will override any previously set `rtcConfiguration` within `Device.options` but not affect any other members set within `Device.options`.
+
+1.13.1 (Jan 11, 2020)
+=======
 
 Additions
 ---------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-1.13.2 (In Progress)
+1.14.0 (In Progress)
 ====================
 
 New Features

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -547,14 +547,16 @@ class Connection extends EventEmitter {
   /**
    * Accept the incoming {@link Connection}.
    * @param [audioConstraints]
+   * @param [iceServers] - An array of ICE servers to override those set in `Device.setup`.
    */
-  accept(audioConstraints?: MediaTrackConstraints | boolean): void;
+  accept(audioConstraints?: MediaTrackConstraints | boolean, iceServers?: RTCIceServer[]): void;
   /**
    * @deprecated - Set a handler for the {@link acceptEvent}
    * @param handler
    */
   accept(handler: (connection: this) => void): void;
-  accept(handlerOrConstraints?: ((connection: this) => void) | MediaTrackConstraints | boolean): void {
+  accept(handlerOrConstraints?: ((connection: this) => void) | MediaTrackConstraints | boolean,
+         iceServers?: RTCIceServer[]): void {
     if (typeof handlerOrConstraints === 'function') {
       this._addHandler('accept', handlerOrConstraints);
       return;
@@ -603,6 +605,10 @@ class Connection extends EventEmitter {
       }
 
       this.pstream.addListener('hangup', this._onHangup);
+
+      if (iceServers) {
+        this.options.rtcConfiguration = { ...this.options.rtcConfiguration, iceServers };
+      }
 
       if (this._direction === Connection.CallDirection.Incoming) {
         this._isAnswered = true;

--- a/lib/twilio/connection.ts
+++ b/lib/twilio/connection.ts
@@ -547,16 +547,16 @@ class Connection extends EventEmitter {
   /**
    * Accept the incoming {@link Connection}.
    * @param [audioConstraints]
-   * @param [iceServers] - An array of ICE servers to override those set in `Device.setup`.
+   * @param [rtcConfiguration] - An RTCConfiguration to override the one set in `Device.setup`.
    */
-  accept(audioConstraints?: MediaTrackConstraints | boolean, iceServers?: RTCIceServer[]): void;
+  accept(audioConstraints?: MediaTrackConstraints | boolean, rtcConfiguration?: RTCConfiguration): void;
   /**
    * @deprecated - Set a handler for the {@link acceptEvent}
    * @param handler
    */
   accept(handler: (connection: this) => void): void;
   accept(handlerOrConstraints?: ((connection: this) => void) | MediaTrackConstraints | boolean,
-         iceServers?: RTCIceServer[]): void {
+         rtcConfiguration?: RTCConfiguration): void {
     if (typeof handlerOrConstraints === 'function') {
       this._addHandler('accept', handlerOrConstraints);
       return;
@@ -606,20 +606,18 @@ class Connection extends EventEmitter {
 
       this.pstream.addListener('hangup', this._onHangup);
 
-      if (iceServers) {
-        this.options.rtcConfiguration = { ...this.options.rtcConfiguration, iceServers };
-      }
+      rtcConfiguration = rtcConfiguration || this.options.rtcConfiguration;
 
       if (this._direction === Connection.CallDirection.Incoming) {
         this._isAnswered = true;
         this.mediaStream.answerIncomingCall(this.parameters.CallSid, this.options.offerSdp,
-          this.options.rtcConstraints, this.options.rtcConfiguration, onAnswer);
+          this.options.rtcConstraints, rtcConfiguration, onAnswer);
       } else {
         const params = Array.from(this.customParameters.entries()).map(pair =>
          `${encodeURIComponent(pair[0])}=${encodeURIComponent(pair[1])}`).join('&');
         this.pstream.once('answer', this._onAnswer.bind(this));
         this.mediaStream.makeOutgoingCall(this.pstream.token, params, this.outboundConnectionId,
-          this.options.rtcConstraints, this.options.rtcConfiguration, onAnswer);
+          this.options.rtcConstraints, rtcConfiguration, onAnswer);
       }
     };
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -469,11 +469,11 @@ class Device extends EventEmitter {
    * Make an outgoing Call.
    * @param [params] - A flat object containing key:value pairs to be sent to the TwiML app.
    * @param [audioConstraints]
-   * @param [iceServers] - An array of ICE servers to override those set in `Device.setup`.
+   * @param [rtcConfiguration] - An RTCConfiguration to override the one set in `Device.setup`.
    */
   connect(params?: Record<string, string>,
           audioConstraints?: MediaTrackConstraints | boolean,
-          iceServers?: RTCIceServer[]): Connection;
+          rtcConfiguration?: RTCConfiguration): Connection;
   /**
    * Add a listener for the connect event.
    * @param handler - A handler to set on the connect event.
@@ -481,7 +481,7 @@ class Device extends EventEmitter {
   connect(handler: (connection: Connection) => any): null;
   connect(paramsOrHandler?: Record<string, string> | ((connection: Connection) => any),
           audioConstraints?: MediaTrackConstraints | boolean,
-          iceServers?: RTCIceServer[]): Connection | null {
+          rtcConfiguration?: RTCConfiguration): Connection | null {
     if (typeof paramsOrHandler === 'function') {
       this._addHandler(Device.EventName.Connect, paramsOrHandler);
       return null;
@@ -495,11 +495,7 @@ class Device extends EventEmitter {
 
     const params: Record<string, string> = paramsOrHandler || { };
     audioConstraints = audioConstraints || this.options && this.options.audioConstraints || { };
-
-    const rtcConfiguration = this.options.rtcConfiguration || { iceServers: this.options.iceServers };
-    if (iceServers) {
-      rtcConfiguration.iceServers = iceServers;
-    }
+    rtcConfiguration = rtcConfiguration || this.options.rtcConfiguration;
 
     const connection = this._activeConnection = this._makeConnection(params, { rtcConfiguration });
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -469,16 +469,19 @@ class Device extends EventEmitter {
    * Make an outgoing Call.
    * @param [params] - A flat object containing key:value pairs to be sent to the TwiML app.
    * @param [audioConstraints]
+   * @param [iceServers] - An array of ICE servers to override those set in `Device.setup`.
    */
   connect(params?: Record<string, string>,
-          audioConstraints?: MediaTrackConstraints | boolean): Connection;
+          audioConstraints?: MediaTrackConstraints | boolean,
+          iceServers?: RTCIceServer[]): Connection;
   /**
    * Add a listener for the connect event.
    * @param handler - A handler to set on the connect event.
    */
   connect(handler: (connection: Connection) => any): null;
   connect(paramsOrHandler?: Record<string, string> | ((connection: Connection) => any),
-          audioConstraints?: MediaTrackConstraints | boolean): Connection | null {
+          audioConstraints?: MediaTrackConstraints | boolean,
+          iceServers?: RTCIceServer[]): Connection | null {
     if (typeof paramsOrHandler === 'function') {
       this._addHandler(Device.EventName.Connect, paramsOrHandler);
       return null;
@@ -492,7 +495,13 @@ class Device extends EventEmitter {
 
     const params: Record<string, string> = paramsOrHandler || { };
     audioConstraints = audioConstraints || this.options && this.options.audioConstraints || { };
-    const connection = this._activeConnection = this._makeConnection(params);
+
+    const rtcConfiguration = this.options.rtcConfiguration || { iceServers: this.options.iceServers };
+    if (iceServers) {
+      rtcConfiguration.iceServers = iceServers;
+    }
+
+    const connection = this._activeConnection = this._makeConnection(params, { rtcConfiguration });
 
     // Make sure any incoming connections are ignored
     this.connections.splice(0).forEach(conn => conn.ignore());

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -492,15 +492,13 @@ describe('Connection', function() {
           });
         });
 
-        it('should call mediaStream.answerIncomingCall with override iceServers', () => {
-          const originalOptions = conn['options'];
-          const iceServers = [{ urls: 'foo-ice-server-url' }];
-          conn.accept(undefined, iceServers);
+        it('should call mediaStream.answerIncomingCall with override `rtcConfiguration`', () => {
+          const rtcConfiguration = {
+            iceServers: [{ urls: 'foo-ice-server-url' }],
+          };
+          conn.accept(undefined, rtcConfiguration);
           return wait.then(() => {
-            assert.deepEqual(mediaStream.answerIncomingCall.args[0][3], {
-              ...originalOptions.rtcConfiguration,
-              iceServers,
-            });
+            assert.deepEqual(mediaStream.answerIncomingCall.args[0][3], rtcConfiguration);
           });
         });
 
@@ -577,15 +575,13 @@ describe('Connection', function() {
           });
         });
 
-        it('should call mediaStream.makeOutgoingCall with an override iceServers', () => {
-          const originalOptions = conn['options'];
-          const iceServers = [{ urls: 'foo-ice-server-url' }];
-          conn.accept(undefined, iceServers);
+        it('should call mediaStream.makeOutgoingCall with an override `rtcConfiguration`', () => {
+          const rtcConfiguration = {
+            iceServers: [{ urls: 'foo-ice-server-url' }],
+          };
+          conn.accept(undefined, rtcConfiguration);
           return wait.then(() => {
-            assert.deepEqual(mediaStream.makeOutgoingCall.args[0][4], {
-              ...originalOptions.rtcConfiguration,
-              iceServers,
-            });
+            assert.deepEqual(mediaStream.makeOutgoingCall.args[0][4], rtcConfiguration);
           });
         });
 

--- a/tests/unit/connection.ts
+++ b/tests/unit/connection.ts
@@ -492,6 +492,18 @@ describe('Connection', function() {
           });
         });
 
+        it('should call mediaStream.answerIncomingCall with override iceServers', () => {
+          const originalOptions = conn['options'];
+          const iceServers = [{ urls: 'foo-ice-server-url' }];
+          conn.accept(undefined, iceServers);
+          return wait.then(() => {
+            assert.deepEqual(mediaStream.answerIncomingCall.args[0][3], {
+              ...originalOptions.rtcConfiguration,
+              iceServers,
+            });
+          });
+        });
+
         context('when the success callback is called', () => {
           it('should publish an accepted-by-local event', () => {
             conn.accept();
@@ -562,6 +574,18 @@ describe('Connection', function() {
             sinon.assert.calledOnce(mediaStream.makeOutgoingCall);
             assert.equal(mediaStream.makeOutgoingCall.args[0][1],
               'To=foo&a=undefined&b=true&c=false&d=&e=123&f=123&g=null&h=undefined&i=null&j=0&k=0&l=a%24b%26c%3Fd%3De');
+          });
+        });
+
+        it('should call mediaStream.makeOutgoingCall with an override iceServers', () => {
+          const originalOptions = conn['options'];
+          const iceServers = [{ urls: 'foo-ice-server-url' }];
+          conn.accept(undefined, iceServers);
+          return wait.then(() => {
+            assert.deepEqual(mediaStream.makeOutgoingCall.args[0][4], {
+              ...originalOptions.rtcConfiguration,
+              iceServers,
+            });
           });
         });
 

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -188,7 +188,7 @@ describe('Device', function() {
       });
     });
 
-    describe('.connect(params?, audioConstraints?)', () => {
+    describe('.connect(params?, audioConstraints?, iceServers?)', () => {
       it('should throw an error', () => {
         assert.throws(() => device.connect(), NOT_INITIALIZED_ERROR);
       });
@@ -350,7 +350,7 @@ describe('Device', function() {
       });
     });
 
-    describe('.connect(params?, audioConstraints?)', () => {
+    describe('.connect(params?, audioConstraints?, iceServers?)', () => {
       it('should throw an error if there is already an active connection', () => {
         device.connect();
         assert.throws(() => device.connect(), /A Connection is already active/);
@@ -393,6 +393,30 @@ describe('Device', function() {
         activeConnection._direction = 'OUTGOING';
         activeConnection.emit('accept');
         sinon.assert.calledOnce(spy.play);
+      });
+
+      context('when passed iceServers', () => {
+        it('should override the iceServers in `Device.options.rtcConfiguration`', () => {
+          device['options'].rtcConfiguration = {
+            ...device['options'].rtcConfiguration,
+            iceServers: [{ urls: 'foo-url' }],
+          };
+          const iceServers = [{ urls: 'bar-url' }];
+          device.connect(undefined, undefined, iceServers);
+          assert(connectOptions && connectOptions.rtcConfiguration);
+          assert.deepEqual(((connectOptions || {}).rtcConfiguration || {}).iceServers, iceServers);
+        });
+
+        it('should leave other `rtcConfiguration` members untouched', () => {
+          device['options'].rtcConfiguration = {
+            ...device['options'].rtcConfiguration,
+            iceServers: [{ urls: 'foo-url' }],
+          };
+          const iceServers = [{ urls: 'bar-url' }];
+          device.connect(undefined, undefined, iceServers);
+          assert(connectOptions && connectOptions.rtcConfiguration);
+          assert.deepEqual((connectOptions || {}).rtcConfiguration, { ...device['options'].rtcConfiguration, iceServers });
+        });
       });
     });
 

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -395,27 +395,19 @@ describe('Device', function() {
         sinon.assert.calledOnce(spy.play);
       });
 
-      context('when passed iceServers', () => {
-        it('should override the iceServers in `Device.options.rtcConfiguration`', () => {
+      context('when passed an `rtcConfiguration`', () => {
+        it('should override the `rtcConfiguration` in `Device.options`', () => {
+          const overrideRtcConfiguration = {
+            ...device['options'].rtcConfiguration,
+            iceServers: [{ urls: 'bar-url' }],
+          };
           device['options'].rtcConfiguration = {
             ...device['options'].rtcConfiguration,
             iceServers: [{ urls: 'foo-url' }],
           };
-          const iceServers = [{ urls: 'bar-url' }];
-          device.connect(undefined, undefined, iceServers);
+          device.connect(undefined, undefined, overrideRtcConfiguration);
           assert(connectOptions && connectOptions.rtcConfiguration);
-          assert.deepEqual(((connectOptions || {}).rtcConfiguration || {}).iceServers, iceServers);
-        });
-
-        it('should leave other `rtcConfiguration` members untouched', () => {
-          device['options'].rtcConfiguration = {
-            ...device['options'].rtcConfiguration,
-            iceServers: [{ urls: 'foo-url' }],
-          };
-          const iceServers = [{ urls: 'bar-url' }];
-          device.connect(undefined, undefined, iceServers);
-          assert(connectOptions && connectOptions.rtcConfiguration);
-          assert.deepEqual((connectOptions || {}).rtcConfiguration, { ...device['options'].rtcConfiguration, iceServers });
+          assert.deepEqual((connectOptions || {}).rtcConfiguration, overrideRtcConfiguration);
         });
       });
     });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7730](https://issues.corp.twilio.com/browse/CLIENT-7730)

### Description

Introduces a new parameter for `Device.connect` and `Connection.accept` to allow for `Connection` specific ICE Servers.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
