### PR TITLE
[CLIENT-8269] Expose `loglevel` usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+2.0.0 (In Progress)
+===================
+
+New Features
+------------
+
+### LogLevel Module
+
+The SDK now uses the [`loglevel`](https://github.com/pimterry/loglevel) module. This exposes several new features for the SDK, including the ability to intercept log messages with custom handlers and the ability to set logging levels after instantiating a `Device`. To get an instance of the `loglevel` `Logger` class used internally by the SDK, there are several options.
+
+If your project uses the `Twilio` window global:
+```js
+const logger = Twilio.Logger;
+...
+logger.setLogLevel('DEBUG');
+```
+
+Or if you use the `NPM` package in a JS or TS project:
+```ts
+import { Logger as TwilioClientLogger } from 'twilio-client.js`;
+...
+TwilioClientLogger.setLogLevel('DEBUG');
+```
+
+Please see the original [`loglevel`](https://github.com/pimterry/loglevel) project for more documentation on usage.
+
 1.14.0 (Jan 27, 2021)
 ====================
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -15,5 +15,6 @@ $license
     Twilio.Device = Twilio.Device || Voice.Device;
     Twilio.PStream = Twilio.PStream || Voice.PStream;
     Twilio.PreflightTest = Twilio.PreflightTest || Voice.PreflightTest;
+    Twilio.Logger = Twilio.Logger || Voice.Logger;
   }
 })(typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : this);

--- a/lib/twilio.ts
+++ b/lib/twilio.ts
@@ -4,6 +4,7 @@
  */
 import Connection from './twilio/connection';
 import Device from './twilio/device';
+import { Logger } from './twilio/log';
 import { PreflightTest } from './twilio/preflight/preflight' ;
 
-export { Connection, Device, PreflightTest };
+export { Connection, Device, PreflightTest, Logger };

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -5,6 +5,7 @@
  * @publicapi
  */
 import { EventEmitter } from 'events';
+import { levels as LogLevels, LogLevelDesc } from 'loglevel';
 import AudioHelper from './audiohelper';
 import Connection from './connection';
 import DialtonePlayer from './dialtonePlayer';
@@ -370,19 +371,18 @@ class Device extends EventEmitter {
     closeProtection: false,
     codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
     connectionFactory: Connection,
-    debug: false,
     dscp: true,
     enableIceRestart: false,
     eventgw: 'eventgw.twilio.com',
     forceAggressiveIceNomination: false,
     iceServers: [],
+    logLevel: LogLevels.ERROR,
     noRegister: false,
     pStreamFactory: PStream,
     preflight: false,
     rtcConstraints: { },
     soundFactory: Sound,
     sounds: { },
-    warnings: true,
   };
 
   /**
@@ -667,11 +667,9 @@ class Device extends EventEmitter {
     Object.assign(this.options, options);
 
     this._log.setDefaultLevel(
-      this.options.debug
-        ? Log.levels.DEBUG
-        : this.options.warnings
-          ? Log.levels.WARN
-          : Log.levels.SILENT,
+      typeof this.options.logLevel === 'number'
+        ? this.options.logLevel
+        : LogLevels.ERROR,
     );
 
     this._chunderURIs = this.options.chunderw
@@ -1583,11 +1581,6 @@ namespace Device {
     codecPreferences?: Connection.Codec[];
 
     /**
-     * Whether to enable debug logging.
-     */
-    debug?: boolean;
-
-    /**
      * Whether AudioContext sounds should be disabled. Useful for trouble shooting sound issues
      * that may be caused by AudioContext-specific sounds. If set to true, will fall back to
      * HTMLAudioElement sounds.
@@ -1632,6 +1625,11 @@ namespace Device {
      * Whether to use ICE Aggressive nomination.
      */
     forceAggressiveIceNomination?: boolean;
+
+    /**
+     * Log level.
+     */
+    logLevel?: LogLevelDesc;
 
     /**
      * The maximum average audio bitrate to use, in bits per second (bps) based on
@@ -1686,11 +1684,6 @@ namespace Device {
      * A mapping of custom sound URLs by sound name.
      */
     sounds?: Partial<Record<Device.SoundName, string>>;
-
-    /**
-     * Whether to enable warn logging.
-     */
-    warnings?: boolean;
   }
 }
 

--- a/lib/twilio/log.ts
+++ b/lib/twilio/log.ts
@@ -74,6 +74,14 @@ class Log {
   }
 
   /**
+   * Return the `loglevel` instance maintained internally.
+   * @returns The `loglevel` instance.
+   */
+  getLogLevelInstance(): LogLevelModule.Logger {
+    return this._log;
+  }
+
+  /**
    * Log an info message
    * @param args - Any number of arguments to be passed to loglevel.info
    */
@@ -96,5 +104,7 @@ class Log {
     this._log.warn(...args);
   }
 }
+
+export const Logger = Log.getInstance().getLogLevelInstance();
 
 export default Log;

--- a/tests/integration/logger.ts
+++ b/tests/integration/logger.ts
@@ -1,0 +1,8 @@
+import * as assert from 'assert';
+import { Logger } from '../../lib/twilio';
+
+describe('Logger', () => {
+  it('the exposed logger should be defined', () => {
+    assert(Logger);
+  });
+});

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -147,24 +147,11 @@ describe('Device', function() {
         device['_log'].setDefaultLevel = setDefaultLevelStub;
       });
 
-      it('should set log level to DEBUG if debug is true and warnings is true', () => {
-        device.setup(token, Object.assign({ debug: true, warnings: true }, setupOptions));
-        sinon.assert.calledWith(setDefaultLevelStub, LogLevels.DEBUG);
-      });
-
-      it('should set log level to DEBUG if debug is true and warnings is false', () => {
-        device.setup(token, Object.assign({ debug: true, warnings: false }, setupOptions));
-        sinon.assert.calledWith(setDefaultLevelStub, LogLevels.DEBUG);
-      });
-
-      it('should set log level to WARN if debug is false and warnings is true', () => {
-        device.setup(token, Object.assign({ debug: false, warnings: true }, setupOptions));
-        sinon.assert.calledWith(setDefaultLevelStub, LogLevels.WARN);
-      });
-
-      it('should set log level to SILENT if debug is false and warnings is false', () => {
-        device.setup(token, Object.assign({ debug: false, warnings: false }, setupOptions));
-        sinon.assert.calledWith(setDefaultLevelStub, LogLevels.SILENT);
+      Object.entries(LogLevels).forEach(([level, number]) => {
+        it(`should set log level to '${level}'`, () => {
+          device.setup(token, Object.assign({ logLevel: number }, setupOptions));
+          sinon.assert.calledWith(setDefaultLevelStub, number);
+        });
       });
     });
   });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-8269](https://issues.corp.twilio.com/browse/CLIENT-8269)

### Description

This PR removes the `Device` logging options `debug` and `warning` in favor of a standardized `logLevel` description or number such as `'ERROR'` or the numerical equivalent `4`. This PR is an API change towards `twilio-client.js@2.x`.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
