### PR TITLE
[CLIENT-8337] and [CLIENT-8338] Lazy Signaling and Device States

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,8 @@ enum.
 
 ```ts
 export enum EventName {
-  // Device and Connection errors.
   Error = 'error',
-
-  // Connection events.
-  Cancel = 'cancel',
-  Connect = 'connect',
-  Disconnect = 'disconnect',
   Incoming = 'incoming',
-
-  // Device Registration events.
   Unregistered = 'unregistered',
   Registering = 'registering',
   Registered = 'registered',
@@ -48,22 +40,19 @@ async Device.register(): Promise<void>;
 async Device.connect(options?: Device.ConnectOptions): Promise<Call>;
 ```
 
-- `Device.updateOptions` may be called when there are no connections maintained by
+- `Device.updateOptions` may be called when there are no calls maintained by
 the `Device`. Updating options that change the `Device`'s connection to the
 Twilio backend will cause a re-registration if the `Device` is registered when
 calling `Device.updateOptions`.
 
-- `Device.register` returns a `Promise<void>` such that when the `Device` has
-received a signal from the Twilio backend that the signaling service has
-successfully connected and the `Device` is registered, the returned
-`Promise<void>` will resolve.
+- `Device.register` returns a Promise that resolves when the `Device` has
+successfully connected to the Twilio backend and the `Device` is registered.
 
-- `Device.connect` returns a `Promise<Call>` such that when the `Device` has
-received a signal from the Twilio backend that the signaling service has
-successfully connected and a call has been made, the returned `Promise<Call>`
-will resolve.
+- `Device.connect` returns a Promise that resolves with a `Call` when the
+`Device` has successfully connected to the Twilio backend and a call has been
+made.
 
-Listening for incoming calls:
+#### Listening for incoming calls:
 ```ts
 const token = '...';
 const options = { edge: 'ashburn', ... };
@@ -73,7 +62,7 @@ device.on(Device.EventName.Incoming, call => { /* use `call` here */ });
 await device.register(token, customRegisterOptions);
 ```
 
-Making an outgoing call:
+#### Making an outgoing call:
 ```ts
 const token = '...';
 const options = { edge: 'ashburn', ... };
@@ -82,7 +71,7 @@ const device = new Device(token, options);
 const call = await device.call({ To: 'foobar' });
 ```
 
-Using a device for both incoming and outgoing calls:
+#### Using a device for both incoming and outgoing calls:
 ```ts
 const token = '...';
 const options = { edge: 'ashburn', ... };
@@ -99,7 +88,11 @@ New Features
 
 ### Device Options
 
-The SDK now allows `Device` options to be changed after initial set up.
+The SDK now allows `Device` options to be changed after initial set up using
+`async Device.updateOptions(options?: Device.Options)`. It will return a Promise
+that resolves when the options have been successfully updated within the
+`Device`. If the `Device` is registered before calling `Device.updateOptions`,
+the `Device` will re-register before resolving the returned Promise.
 
 Example usage:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,60 +10,88 @@ The formula used to calculate the mean-opinion score (MOS) has
 been fixed for extreme network conditions. These fixes should not change score
 values for nominal network conditions.
 
-### Device Listening
+### Device Events
 
-Formerly, `Device.registerPresence` and `Device.unregisterPresence` were used to
-notify the Twilio backend whether or not the `Device` was listening for calls.
-
-Now, `Device.listen(shouldListen: boolean)` has replaced both functions where
-`Device.listen(true)` replaces `Device.registerPresence` and vice-versa. It is
-not necessary to call `Device.listen(true)` after registering the device
-using `Device.register(token: string, options?: Device.Options)`.
-
-### Device Call Signature
-
-To modernize the SDK, the call signature and usage of `Device` has changed.
+The events emitted by the `Device` are now exposed as the `Device.EventName`
+enum.
 
 ```ts
-new Device(options?: Device.Options);
-Device.setOptions(options: Device.Options);
-async Device.register(token: string, options: Device.RegisterOptions);
+export enum EventName {
+  // Device and Connection errors.
+  Error = 'error',
+
+  // Connection events.
+  Cancel = 'cancel',
+  Connect = 'connect',
+  Disconnect = 'disconnect',
+  Incoming = 'incoming',
+
+  // Device Registration events.
+  Unregistered = 'unregistered',
+  Registering = 'registering',
+  Registered = 'registered',
+}
 ```
 
-If `Device` is constructed without any parameters, then it will be instantiated
-with default options. Then, to connect the `Device` to the Twilio servers, a
-call to `Device.register` must be performed.
+Note that `unregistered`, `registering`, and `registered` have replaced
+`offline` and `ready`.
 
-`Device.register` returns a `Promise<this>` such that when the `Device` has
-received a signal from the Twilio backend that the signaling service has
-successfully connected, the returned `Promise<this>` will resolve with the
-ready to use device.
+### Device Usage
 
-`Device.setOptions` may be called when there are no connections maintained by
-the `Device`.
-
-Example Usage:
+The construction signature and usage of `Device` has changed.
 
 ```ts
-const token = '...';
-const customOptions = { ... };
-const customRegisterOptions = { edge: 'ashburn', ... };
-const device = new Device();
-device.on(Device.EventName.Ready, (readyDevice: Device) => {
-  /* use device here */
-});
-device.setOptions(customOptions);
-device.register(token, customRegisterOptions);
+new Device(token: string, options?: Device.Options): Device;
 
-// Or...
+async Device.updateOptions(options: Device.Options): Promise<void>;
+async Device.register(): Promise<void>;
+async Device.connect(options?: Device.ConnectOptions): Promise<Call>;
+```
 
+- `Device.updateOptions` may be called when there are no connections maintained by
+the `Device`. Updating options that change the `Device`'s connection to the
+Twilio backend will cause a re-registration if the `Device` is registered when
+calling `Device.updateOptions`.
+
+- `Device.register` returns a `Promise<void>` such that when the `Device` has
+received a signal from the Twilio backend that the signaling service has
+successfully connected and the `Device` is registered, the returned
+`Promise<void>` will resolve.
+
+- `Device.connect` returns a `Promise<Call>` such that when the `Device` has
+received a signal from the Twilio backend that the signaling service has
+successfully connected and a call has been made, the returned `Promise<Call>`
+will resolve.
+
+Listening for incoming calls:
+```ts
 const token = '...';
-const customOptions = { ... };
-const customRegisterOptions = { edge: 'ashburn', ... };
-const device = new Device();
-device.setOptions(customOptions);
-const readyDevice = await device.register(token, customRegisterOptions);
-/* use device here */
+const options = { edge: 'ashburn', ... };
+const device = new Device(token, options);
+
+device.on(Device.EventName.Incoming, call => { /* use `call` here */ });
+await device.register(token, customRegisterOptions);
+```
+
+Making an outgoing call:
+```ts
+const token = '...';
+const options = { edge: 'ashburn', ... };
+const device = new Device(token, options);
+
+const call = await device.call({ To: 'foobar' });
+```
+
+Using a device for both incoming and outgoing calls:
+```ts
+const token = '...';
+const options = { edge: 'ashburn', ... };
+const device = new Device(token, options);
+
+device.on(Device.EventName.Incoming, call => { /* use `call` here */ });
+await device.register();
+
+const call = await device.call({ To: 'foobar' });
 ```
 
 New Features
@@ -71,11 +99,7 @@ New Features
 
 ### Device Options
 
-The SDK now allows `Device` options to be changed after initial set up. The
-passable `Device` options have changed significantly; options that cause a
-change in the connection to the Twilio backend (such as signaling edge, insights
-options, etc.) are now separated and consolidated within a new interface
-`Device.RegisterOptions`.
+The SDK now allows `Device` options to be changed after initial set up.
 
 Example usage:
 
@@ -84,14 +108,12 @@ const token = '...';
 const device = new Device(token);
 
 const options1 = { ... };
-device.setOptions(options1);
-device.once(Device.EventName.Ready, (dev: Device) => { /* use device here */ });
+device.updateOptions(options1);
 
 ...
 
 const options2 = { ... };
-device.setOptions(options2);
-device.once(Device.EventName.Ready, (dev: Device) => { /* use device here */ });
+device.updateOptions(options2);
 ```
 
 ### LogLevel Module
@@ -132,7 +154,7 @@ API Changes
 The arguments for `Device.connect()` and `Connection.accept()` have been standardized
 to the following options objects:
 
-```
+```ts
 interface Device.ConnectOptions extends Connection.AcceptOptions {
  /**
   * A flat object containing key:value pairs to be sent to the TwiML app.
@@ -141,7 +163,7 @@ interface Device.ConnectOptions extends Connection.AcceptOptions {
 }
 ```
 
-```
+```ts
 interface Connection.AcceptOptions {
   /**
    * An RTCConfiguration to pass to the RTCPeerConnection constructor.
@@ -156,12 +178,12 @@ interface Connection.AcceptOptions {
 ```
 
 Note that these now take a [MediaStreamConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints) rather than just the audio constraints. For example:
-```
+```ts
 device.connect({ To: 'client:alice' }, { deviceId: 'default' });
 ```
 
 might be re-written as:
-```
+```ts
 device.connect({
   params: { To: 'client:alice' },
   rtcConstraints: { audio: { deviceId: 'default' } },
@@ -170,7 +192,7 @@ device.connect({
 
 ### Removal of Deprecated Device Options
 
-As part of 2.x, some deprecated `Device` options have been removed. This includes:
+Some deprecated `Device` options have been removed. This includes:
 
 * `enableIceRestart`
 * `enableRingingState`

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -411,7 +411,7 @@ class Device extends EventEmitter {
   /**
    * A promise that will resolve when the Signaling stream is ready.
    */
-  private _streamReadyPromise: Promise<IPStream> | null = null;
+  private _streamConnectedPromise: Promise<IPStream> | null = null;
 
   /**
    * The JWT string currently being used to authenticate this {@link Device}.
@@ -882,7 +882,7 @@ class Device extends EventEmitter {
       audioHelper: this._audio,
       getUserMedia,
       isUnifiedPlanDefault: Device._isUnifiedPlanDefault,
-      pstream: await (this._streamReadyPromise || this._setupStream()),
+      pstream: await (this._streamConnectedPromise || this._setupStream()),
       publisher: this._publisher,
       soundcache: this._soundcache,
     };
@@ -1009,7 +1009,6 @@ class Device extends EventEmitter {
     const region = getRegionShortcode(payload.region);
     this._edge = regionToEdge[region as Region] || payload.region;
     this._region = region || payload.region;
-    this._sendPresence();
   }
 
   /**
@@ -1148,7 +1147,7 @@ class Device extends EventEmitter {
    * Register with the signaling server.
    */
   private async _sendPresence(): Promise<void> {
-    const stream = await (this._streamReadyPromise || this._setupStream());
+    const stream = await (this._streamConnectedPromise || this._setupStream());
     stream.register({ audio: this._mediaPresence.audio });
     if (this._mediaPresence.audio) {
       this._startRegistrationTimer();
@@ -1249,7 +1248,7 @@ class Device extends EventEmitter {
     this._stream.addListener('offline', this._onSignalingOffline);
     this._stream.addListener('ready', this._onSignalingReady);
 
-    return this._streamReadyPromise = new Promise<this>(resolve =>
+    return this._streamConnectedPromise = new Promise<this>(resolve =>
       this._stream.once('connected', () => {
         resolve(this._stream);
       }),

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -58,6 +58,7 @@ export type ISound = any;
 const REGISTRATION_INTERVAL = 30000;
 const RINGTONE_PLAY_TIMEOUT = 2000;
 const PUBLISHER_PRODUCT_NAME = 'twilio-js-sdk';
+const INVALID_TOKEN_MESSAGE = 'Parameter "token" must be of type "string".';
 
 declare const RTCRtpTransceiver: any;
 declare const webkitAudioContext: typeof AudioContext;
@@ -73,14 +74,25 @@ export interface IExtendedDeviceOptions extends Device.Options {
   AudioHelper?: typeof AudioHelper;
 
   /**
+   * The max amount of time in milliseconds to allow stream (re)-connect
+   * backoffs.
+   */
+  backoffMaxMs?: number;
+
+  /**
    * Hostname of the signaling gateway to connect to.
    */
-  chunderw?: string;
+  chunderw?: string | string[];
 
   /**
    * Custom {@link Connection} constructor
    */
   Connection?: typeof Connection;
+
+  /**
+   * Hostname of the event gateway to connect to.
+   */
+  eventgw?: string;
 
   /**
    * File input stream to use instead of reading from mic
@@ -114,14 +126,14 @@ export interface IExtendedDeviceOptions extends Device.Options {
   Publisher?: IPublisher;
 
   /**
-   * Whether Insights events should be published
+   * Whether or not to publish events to insights using {@link Device._publisher}.
    */
   publishEvents?: boolean;
 
   /**
-   * Whether to disable audio flag in MediaPresence (rrowland: Do we need this?)
+   * MediaStreamConstraints to pass to getUserMedia when making or accepting a Call.
    */
-  shouldListen?: boolean;
+  rtcConstraints?: Connection.AcceptOptions['rtcConstraints'];
 
   /**
    * Custom Sound constructor
@@ -279,8 +291,14 @@ class Device extends EventEmitter {
    */
   private _audio: AudioHelper | null = null;
 
+  /**
+   * {@link Device._confirmClose} bound to the specific {@link Device} instance.
+   */
   private _boundConfirmClose: typeof Device.prototype._confirmClose;
 
+  /**
+   * {@link Device.destroy} bound to the specific {@link Device} instance.
+   */
   private _boundDestroy: typeof Device.prototype.destroy;
 
   /**
@@ -313,18 +331,11 @@ class Device extends EventEmitter {
     closeProtection: false,
     codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
     dscp: true,
+    eventgw: 'eventgw.twilio.com',
     forceAggressiveIceNomination: false,
     logLevel: LogLevels.ERROR,
     preflight: false,
-    shouldListen: true,
     sounds: { },
-  };
-
-  /**
-   * Default options used by {@link Device} within {@link Device.register}.
-   */
-  private readonly _defaultRegistrationOptions: Device.RegisterOptions = {
-    eventgw: 'eventgw.twilio.com',
   };
 
   /**
@@ -347,11 +358,6 @@ class Device extends EventEmitter {
   private _isBrowserExtension: boolean;
 
   /**
-   * Whether or not {@link Device.register} has been called.
-   */
-  private _isRegistered: boolean = false;
-
-  /**
    * An instance of Logger to use.
    */
   private _log: Log = Log.getInstance();
@@ -368,7 +374,7 @@ class Device extends EventEmitter {
   private _networkInformation: any;
 
   /**
-   * The options passed to {@link Device} constructor or {@link Device.setOptions}.
+   * The options passed to {@link Device} constructor or {@link Device.updateOptions}.
    */
   private _options: IExtendedDeviceOptions = { };
 
@@ -383,11 +389,6 @@ class Device extends EventEmitter {
   private _region: string | null = null;
 
   /**
-   * The options passed to {@link Device.register}.
-   */
-  private _registerOptions: Device.RegisterOptions = { };
-
-  /**
    * A timeout ID for a setTimeout schedule to re-register the {@link Device}.
    */
   private _regTimer: NodeJS.Timer | null = null;
@@ -400,7 +401,7 @@ class Device extends EventEmitter {
   /**
    * The current status of the {@link Device}.
    */
-  private _status: Device.Status = Device.Status.Offline;
+  private _state: Device.State = Device.State.Unregistered;
 
   /**
    * The Signaling stream.
@@ -408,9 +409,14 @@ class Device extends EventEmitter {
   private _stream: IPStream | null = null;
 
   /**
+   * A promise that will resolve when the Signaling stream is ready.
+   */
+  private _streamReadyPromise: Promise<IPStream> | null = null;
+
+  /**
    * The JWT string currently being used to authenticate this {@link Device}.
    */
-  private _token: string | null = null;
+  private _token: string;
 
   /**
    * Construct a {@link Device} instance. The {@link Device} can be registered
@@ -418,8 +424,10 @@ class Device extends EventEmitter {
    * @constructor
    * @param options
    */
-  constructor(options: Device.Options = { }) {
+  constructor(token: string, options: Device.Options = { }) {
     super();
+
+    this.updateToken(token);
 
     if (isLegacyEdge()) {
       throw new NotSupportedError(
@@ -491,7 +499,7 @@ class Device extends EventEmitter {
       window.addEventListener('pagehide', this._boundDestroy);
     }
 
-    this.setOptions(options);
+    this.updateOptions(options);
   }
 
   /**
@@ -512,17 +520,13 @@ class Device extends EventEmitter {
    * Make an outgoing Call.
    * @param options
    */
-  connect(options?: Device.ConnectOptions): Connection {
-    this._throwUnlessRegistered('connect');
-
+  async connect(options: Device.ConnectOptions = { }): Promise<Connection> {
     if (this._activeConnection) {
       throw new InvalidStateError('A Connection is already active');
     }
 
-    options = options || { };
-
-    const connection = this._activeConnection = this._makeConnection(options!.params || { }, {
-      rtcConfiguration: options!.rtcConfiguration,
+    const connection = this._activeConnection = await this._makeConnection(options.params || { }, {
+      rtcConfiguration: options.rtcConfiguration,
     });
 
     // Make sure any incoming connections are ignored
@@ -547,16 +551,16 @@ class Device extends EventEmitter {
    * Destroy the {@link Device}, freeing references to be garbage collected.
    */
   destroy(): void {
-    this._disconnectAll();
+    this.disconnectAll();
     this._stopRegistrationTimer();
 
     if (this._audio) {
       this._audio._unbind();
     }
 
-    if (this._stream) {
-      this._destroyStream();
-    }
+    this._destroyStream();
+    this._destroyPublisher();
+    this._destroyAudioHelper();
 
     if (this._networkInformation && typeof this._networkInformation.removeEventListener === 'function') {
       this._networkInformation.removeEventListener('change', this._publishNetworkChange);
@@ -573,9 +577,12 @@ class Device extends EventEmitter {
    * Disconnect all {@link Connection}s.
    */
   disconnectAll(): void {
-    this._throwUnlessRegistered('disconnectAll');
+    const connections = this._connections.splice(0);
+    connections.forEach((conn: Connection) => conn.disconnect());
 
-    this._disconnectAll();
+    if (this._activeConnection) {
+      this._activeConnection.disconnect();
+    }
   }
 
   /**
@@ -587,99 +594,75 @@ class Device extends EventEmitter {
   }
 
   /**
-   * Whether or not to tell the signaling stream that this {@link Device} would
-   * like to receive calls. It is not necessary to call this after calling
-   * {@link Device.register}, the {@link Device} will be listening by default.
-   * @param shouldListen
+   * Register the `Device` to the Twilio backend, allowing it to receive calls.
    */
-  listen(shouldListen: boolean): this {
-    this._throwUnlessRegistered('listen');
+  async register(): Promise<void> {
+    if (this._state !== Device.State.Unregistered) {
+      this._log.error(
+        `Attempt to register when device is in state "${this._state}". ` +
+        `Must be "${Device.State.Unregistered}".`,
+      );
+      return;
+    }
 
-    this._mediaPresence.audio = shouldListen;
-    this._sendPresence();
+    this._state = Device.State.Registering;
+    this.emit(Device.EventName.Registering);
 
-    return this;
+    this._mediaPresence.audio = true;
+    await this._sendPresence();
+
+    this._state = Device.State.Registered;
+    this.emit(Device.EventName.Registered);
   }
 
   /**
-   * Register the `Device` to the Twilio backend, allowing it send and receive
-   * calls. If the `Device` is already registered, this will allow the user to
-   * update the token or any other registration options. See
-   * {@link Device.RegisterOptions} for more details.
-   * @param token
-   * @param options
+   * Get the state of this {@link Device} instance
    */
-  async register(token: string, options: Device.RegisterOptions = { }): Promise<this> {
-    if (typeof token !== 'string') {
-      throw new InvalidArgumentError('Parameter `token` must be of type `string`.');
+  get state(): Device.State {
+    return this._state;
+  }
+
+  /**
+   * Get the token used by this {@link Device}.
+   */
+  get token(): string | null {
+    return this._token;
+  }
+
+  /**
+   * String representation of {@link Device} instance.
+   * @private
+   */
+  toString() {
+    return '[Twilio.Device instance]';
+  }
+
+  /**
+   * Unregister the `Device` to the Twilio backend, disallowing it to receive
+   * calls.
+   */
+  async unregister(): Promise<void> {
+    if (this._state !== Device.State.Registered) {
+      this._log.error(
+        `Attempt to unregister when device is in state "${this._state}". ` +
+        `Must be "${Device.State.Registered}".`,
+      );
+      return;
     }
 
-    this._isRegistered = false;
+    this._mediaPresence.audio = false;
+    await this._sendPresence();
 
-    this._token = token;
-
-    const originalOptions = this._registerOptions;
-    const newOptions = this._registerOptions = {
-      ...this._defaultRegistrationOptions,
-      ...options,
-    };
-
-    const originalChunderURIs: Set<string> = new Set(this._chunderURIs);
-
-    const chunderw = typeof this._registerOptions.chunderw === 'string'
-      ? [this._registerOptions.chunderw]
-      : Array.isArray(this._registerOptions.chunderw) && this._registerOptions.chunderw;
-
-    const newChunderURIs = this._chunderURIs = (
-      chunderw || getChunderURIs(
-        this._registerOptions.edge,
-        undefined,
-        this._log.warn.bind(this._log),
-      )
-    ).map((uri: string) => `wss://${uri}/signal`);
-
-    let hasChunderURIsChanged =
-      originalChunderURIs.size !== newChunderURIs.length;
-
-    if (!hasChunderURIsChanged) {
-      for (const uri of newChunderURIs) {
-        if (!originalChunderURIs.has(uri)) {
-          hasChunderURIsChanged = true;
-          break;
-        }
-      }
-    }
-
-    this._isRegistered = true;
-
-    const havePublisherOptionsChanged =
-      originalOptions.appName !== newOptions.appName ||
-      originalOptions.appVersion !== newOptions.appVersion;
-
-    if (!havePublisherOptionsChanged && this._publisher) {
-      this._publisher.setToken(this._token);
-    } else {
-      this._setupPublisher();
-    }
-
-    if (!hasChunderURIsChanged && this._stream) {
-      this._stream.setToken(this._token);
-    } else {
-      await this._setupStream();
-    }
-
-    return this;
+    this._state = Device.State.Unregistered;
+    this.emit(Device.EventName.Unregistered, '"Device.unregister" called.');
   }
 
   /**
    * Set the options used within the {@link Device}.
    * @param options
    */
-  setOptions(options: Device.Options = { }): void {
-    if (
-      this._isRegistered &&
-      (this._connections.length > 0 || this.activeConnection)
-    ) {
+  async updateOptions(options: Device.Options = { }): Promise<void> {
+    if (this._connections.length > 0 || this.activeConnection) {
       this._log.warn('Existing Device has ongoing connections; ignoring new options.');
       return;
     }
@@ -717,7 +700,41 @@ class Device extends EventEmitter {
 
     this._setupAudioHelper();
 
-    this._mediaPresence.audio = Boolean(this._options.shouldListen);
+    this._setupPublisher();
+
+    const originalChunderURIs: Set<string> = new Set(this._chunderURIs);
+
+    const chunderw = typeof this._options.chunderw === 'string'
+      ? [this._options.chunderw]
+      : Array.isArray(this._options.chunderw) && this._options.chunderw;
+
+    const newChunderURIs = this._chunderURIs = (
+      chunderw || getChunderURIs(
+        this._options.edge,
+        undefined,
+        this._log.warn.bind(this._log),
+      )
+    ).map((uri: string) => `wss://${uri}/signal`);
+
+    let hasChunderURIsChanged =
+      originalChunderURIs.size !== newChunderURIs.length;
+
+    if (!hasChunderURIsChanged) {
+      for (const uri of newChunderURIs) {
+        if (!originalChunderURIs.has(uri)) {
+          hasChunderURIsChanged = true;
+          break;
+        }
+      }
+    }
+
+    if (hasChunderURIsChanged && this._stream) {
+      const shouldReRegister = this.state === Device.State.Registered;
+      await this._setupStream();
+      if (shouldReRegister) {
+        await this.register();
+      }
+    }
 
     // Setup close protection and make sure we clean up ongoing calls on unload.
     if (
@@ -731,25 +748,23 @@ class Device extends EventEmitter {
   }
 
   /**
-   * Get the status of this {@link Device} instance
+   * Update the token used by this {@link Device} to connect to Twilio.
+   * @param token
    */
-  status(): Device.Status {
-    return this._activeConnection ? Device.Status.Busy : this._status;
-  }
+  updateToken(token: string) {
+    if (typeof token !== 'string') {
+      throw new InvalidArgumentError(INVALID_TOKEN_MESSAGE);
+    }
 
-  /**
-   * Get the token used by this {@link Device}.
-   */
-  get token(): string | null {
-    return this._token;
-  }
+    this._token = token;
 
-  /**
-   * String representation of {@link Device} instance.
-   * @private
-   */
-  toString() {
-    return '[Twilio.Device instance]';
+    if (this._stream) {
+      this._stream.setToken(this._token);
+    }
+
+    if (this._publisher) {
+      this._publisher.setToken(this._token);
+    }
   }
 
   /**
@@ -840,22 +855,8 @@ class Device extends EventEmitter {
     // Attempt to destroy non-existent stream.
     if (!this._stream) { return; }
 
-    this._status = Device.Status.Offline;
-
     this._stream.destroy();
     this._stream = null;
-  }
-
-  /**
-   * Disconnect all {@link Connection}s.
-   */
-  private _disconnectAll = (): void => {
-    const connections = this._connections.splice(0);
-    connections.forEach((conn: Connection) => conn.disconnect());
-
-    if (this._activeConnection) {
-      this._activeConnection.disconnect();
-    }
   }
 
   /**
@@ -872,7 +873,7 @@ class Device extends EventEmitter {
    * @param twimlParams - A flat object containing key:value pairs to be sent to the TwiML app.
    * @param options - Options to be used to instantiate the {@link Connection}.
    */
-  private _makeConnection(twimlParams: Record<string, string>, options?: Connection.Options): Connection {
+  private async _makeConnection(twimlParams: Record<string, string>, options?: Connection.Options): Promise<Connection> {
     if (typeof Device._isUnifiedPlanDefault === 'undefined') {
       throw new InvalidStateError('Device has not been initialized.');
     }
@@ -881,7 +882,7 @@ class Device extends EventEmitter {
       audioHelper: this._audio,
       getUserMedia,
       isUnifiedPlanDefault: Device._isUnifiedPlanDefault,
-      pstream: this._stream,
+      pstream: await (this._streamReadyPromise || this._setupStream()),
       publisher: this._publisher,
       soundcache: this._soundcache,
     };
@@ -923,10 +924,10 @@ class Device extends EventEmitter {
       }
 
       const data: any = { edge: this._edge || this._region };
-      if (this._registerOptions.edge) {
-        data['selected_edge'] = Array.isArray(this._registerOptions.edge)
-          ? this._registerOptions.edge
-          : [this._registerOptions.edge];
+      if (this._options.edge) {
+        data['selected_edge'] = Array.isArray(this._options.edge)
+          ? this._options.edge
+          : [this._options.edge];
       }
 
       this._publisher.info('settings', 'edge', data, connection);
@@ -1047,13 +1048,13 @@ class Device extends EventEmitter {
     }
 
     this._log.info('Received error: ', twilioError);
-    this.emit('error', twilioError, connection);
+    this.emit(Device.EventName.Error, twilioError, connection);
   }
 
   /**
    * Called when an 'invite' event is received from the signaling stream.
    */
-  private _onSignalingInvite = (payload: Record<string, any>) => {
+  private _onSignalingInvite = async (payload: Record<string, any>) => {
     const wasBusy = !!this._activeConnection;
     if (wasBusy && !this._options.allowIncomingWhileBusy) {
       this._log.info('Device busy; ignoring incoming invite');
@@ -1061,7 +1062,7 @@ class Device extends EventEmitter {
     }
 
     if (!payload.callsid || !payload.sdp) {
-      this.emit('error', new ClientErrors.BadRequest('Malformed invite from gateway'));
+      this.emit(Device.EventName.Error, new ClientErrors.BadRequest('Malformed invite from gateway'));
       return;
     }
 
@@ -1069,7 +1070,7 @@ class Device extends EventEmitter {
     callParameters.CallSid = callParameters.CallSid || payload.callsid;
 
     const customParameters = Object.assign({ }, queryToJson(callParameters.Params));
-    const connection = this._makeConnection(customParameters, {
+    const connection = await this._makeConnection(customParameters, {
       callParameters,
       offerSdp: payload.sdp,
     });
@@ -1093,10 +1094,12 @@ class Device extends EventEmitter {
    */
   private _onSignalingOffline = () => {
     this._log.info('Stream is offline');
-    this._status = Device.Status.Offline;
+
     this._edge = null;
     this._region = null;
-    this.emit('offline', this);
+
+    this._state = Device.State.Unregistered;
+    this.emit(Device.EventName.Unregistered, this);
   }
 
   /**
@@ -1104,8 +1107,6 @@ class Device extends EventEmitter {
    */
   private _onSignalingReady = () => {
     this._log.info('Stream is ready');
-    this._status = Device.Status.Ready;
-    this.emit('ready', this);
   }
 
   /**
@@ -1146,10 +1147,9 @@ class Device extends EventEmitter {
   /**
    * Register with the signaling server.
    */
-  private _sendPresence(): void {
-    if (!this._stream) { return; }
-
-    this._stream.register({ audio: this._mediaPresence.audio });
+  private async _sendPresence(): Promise<void> {
+    const stream = await (this._streamReadyPromise || this._setupStream());
+    stream.register({ audio: this._mediaPresence.audio });
     if (this._mediaPresence.audio) {
       this._startRegistrationTimer();
     } else {
@@ -1157,7 +1157,10 @@ class Device extends EventEmitter {
     }
   }
 
-  private _setupAudioHelper() {
+  /**
+   * Set up an audio helper for usage by this {@link Device}.
+   */
+  private _setupAudioHelper(): void {
     if (this._audio) {
       this._log.info('Found existing audio helper; destroying...');
       this._destroyAudioHelper();
@@ -1190,7 +1193,7 @@ class Device extends EventEmitter {
   /**
    * Create and set a publisher for the {@link Device} to use.
    */
-  private _setupPublisher() {
+  private _setupPublisher(): IPublisher {
     if (this._publisher) {
       this._log.info('Found existing publisher; destroying...');
       this._destroyPublisher();
@@ -1201,27 +1204,30 @@ class Device extends EventEmitter {
       this.token,
       {
         defaultPayload: this._createDefaultPayload,
-        host: this._registerOptions.eventgw,
+        host: this._options.eventgw,
         metadata: {
-          app_name: this._registerOptions.appName,
-          app_version: this._registerOptions.appVersion,
+          app_name: this._options.appName,
+          app_version: this._options.appVersion,
         },
       },
     );
 
-    if (this._registerOptions.publishEvents === false) {
+    if (this._options.publishEvents === false) {
       this._publisher.disable();
     } else {
       this._publisher.on('error', (error: Error) => {
         this._log.warn('Cannot connect to insights.', error);
       });
     }
+
+    return this._publisher;
   }
 
   /**
-   * Set up the connection to the signaling server.
+   * Set up the connection to the signaling server. Tears down an existing
+   * stream if called while a stream exists.
    */
-  private _setupStream(): Promise<this> {
+  private _setupStream(): Promise<IPStream> {
     if (this._stream) {
       this._log.info('Found existing stream; destroying...');
       this._destroyStream();
@@ -1232,7 +1238,7 @@ class Device extends EventEmitter {
       this.token,
       this._chunderURIs,
       {
-        backoffMaxMs: this._registerOptions.backoffMaxMs,
+        backoffMaxMs: this._options.backoffMaxMs,
       },
     );
 
@@ -1243,8 +1249,10 @@ class Device extends EventEmitter {
     this._stream.addListener('offline', this._onSignalingOffline);
     this._stream.addListener('ready', this._onSignalingReady);
 
-    return new Promise<this>(resolve =>
-      this._stream.once('ready', () => resolve(this)),
+    return this._streamReadyPromise = new Promise<this>(resolve =>
+      this._stream.once('connected', () => {
+        resolve(this._stream);
+      }),
     );
   }
 
@@ -1267,7 +1275,7 @@ class Device extends EventEmitter {
       this._log.info(reason.message);
     }).then(() => {
       clearTimeout(timeout);
-      this.emit('incoming', connection);
+      this.emit(Device.EventName.Incoming, connection);
     });
   }
 
@@ -1288,14 +1296,6 @@ class Device extends EventEmitter {
     if (this._regTimer) {
       clearTimeout(this._regTimer);
     }
-  }
-
-  /**
-   * Throw an Error if Device.register has not been called for this instance.
-   * @param methodName - The name of the method being called before register()
-   */
-  private _throwUnlessRegistered(methodName: string) {
-    if (!this._isRegistered) { throw new InvalidStateError(`Call Device.register() before ${methodName}`); }
   }
 
   /**
@@ -1432,17 +1432,18 @@ namespace Device {
     Disconnect = 'disconnect',
     Error = 'error',
     Incoming = 'incoming',
-    Offline = 'offline',
-    Ready = 'ready',
+    Unregistered = 'unregistered',
+    Registering = 'registering',
+    Registered = 'registered',
   }
 
   /**
-   * All possible {@link Device} statuses.
+   * All possible {@link Device} states.
    */
-  export enum Status {
-    Busy = 'busy',
-    Offline = 'offline',
-    Ready = 'ready',
+  export enum State {
+    Unregistered = 'unregistered',
+    Registering = 'registering',
+    Registered = 'registered',
   }
 
   /**
@@ -1523,6 +1524,20 @@ namespace Device {
     allowIncomingWhileBusy?: boolean;
 
     /**
+     * A name for the application that is instantiating the {@link Device}. This is used to improve logging
+     * in Insights by associating Insights data with a specific application, particularly in the case where
+     * one account may be connected to by multiple applications.
+     */
+    appName?: string;
+
+    /**
+     * A version for the application that is instantiating the {@link Device}. This is used to improve logging
+     * in Insights by associating Insights data with a specific version of the given application. This can help
+     * track down when application-level bugs were introduced.
+     */
+    appVersion?: string;
+
+    /**
      * Whether to enable close protection, to prevent users from accidentally
      * navigating away from the page during a call. If string, the value will
      * be used as a custom message.
@@ -1547,6 +1562,14 @@ namespace Device {
     dscp?: boolean;
 
     /**
+     * The edge value corresponds to the geographic location that the client
+     * will use to connect to Twilio infrastructure. The default value is
+     * "roaming" which automatically selects an edge based on the latency of the
+     * client relative to available edges.
+     */
+    edge?: string[] | string;
+
+    /**
      * Experimental feature.
      * Whether to use ICE Aggressive nomination.
      */
@@ -1568,64 +1591,9 @@ namespace Device {
     maxAverageBitrate?: number;
 
     /**
-     * MediaStreamConstraints to pass to getUserMedia when making or accepting a Call.
-     * @private
-     */
-    rtcConstraints?: Connection.AcceptOptions['rtcConstraints'];
-
-    /**
      * A mapping of custom sound URLs by sound name.
      */
     sounds?: Partial<Record<Device.SoundName, string>>;
-  }
-
-  export interface RegisterOptions {
-    /**
-     * A name for the application that is instantiating the {@link Device}. This is used to improve logging
-     * in Insights by associating Insights data with a specific application, particularly in the case where
-     * one account may be connected to by multiple applications.
-     */
-    appName?: string;
-
-    /**
-     * A version for the application that is instantiating the {@link Device}. This is used to improve logging
-     * in Insights by associating Insights data with a specific version of the given application. This can help
-     * track down when application-level bugs were introduced.
-     */
-    appVersion?: string;
-
-    /**
-     * The max amount of time in milliseconds to allow stream (re)-connect
-     * backoffs.
-     * @private
-     */
-    backoffMaxMs?: number;
-
-    /**
-     * Chunder gateway URI override.
-     * @private
-     */
-    chunderw?: string | string[];
-
-    /**
-     * The edge value corresponds to the geographic location that the client
-     * will use to connect to Twilio infrastructure. The default value is
-     * "roaming" which automatically selects an edge based on the latency of the
-     * client relative to available edges.
-     */
-    edge?: string[] | string;
-
-    /**
-     * Hostname of the event gateway to connect to.
-     * @private
-     */
-    eventgw?: string;
-
-    /**
-     * Whether or not to publish events to insights using {@link Device._publisher}.
-     * @private
-     */
-    publishEvents?: boolean;
   }
 }
 

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -411,7 +411,7 @@ export class PreflightTest extends EventEmitter {
       }
     }
 
-    this._device.once(Device.EventName.Disconnect, () => {
+    this._connection.once('disconnect', () => {
       this._device.once(Device.EventName.Unregistered, () => this._onUnregistered());
       this._device.destroy();
     });

--- a/tests/integration/device.ts
+++ b/tests/integration/device.ts
@@ -6,7 +6,7 @@ import { generateAccessToken } from '../lib/token';
 
 // (rrowland) The TwiML expected by these tests can be found in the README.md
 
-describe('Device', function() {
+describe.only('Device', function() {
   this.timeout(10000);
 
   let device1: Device;
@@ -21,12 +21,12 @@ describe('Device', function() {
     identity2 = 'id2-' + Date.now();
     token1 = generateAccessToken(identity1);
     token2 = generateAccessToken(identity2);
-    device1 = new Device();
-    device2 = new Device();
+    device1 = new Device(token1);
+    device2 = new Device(token2);
 
     return Promise.all([
-      device1.register(token1),
-      device2.register(token2),
+      device1.register(),
+      device2.register(),
     ]);
   });
 

--- a/tests/integration/device.ts
+++ b/tests/integration/device.ts
@@ -6,7 +6,7 @@ import { generateAccessToken } from '../lib/token';
 
 // (rrowland) The TwiML expected by these tests can be found in the README.md
 
-describe.only('Device', function() {
+describe('Device', function() {
   this.timeout(10000);
 
   let device1: Device;

--- a/tests/integration/icenomination.ts
+++ b/tests/integration/icenomination.ts
@@ -66,8 +66,8 @@ maybeSkip('ICE Nomination', function() {
     // We don't currently expose ice connection state changes.
     // Let's hook to makeConnection and subscribe to events
     const makeConnection = device['_makeConnection'].bind(device);
-    (device['_makeConnection'] as any) = (...params: any) => {
-      const conn = makeConnection(...params);
+    (device['_makeConnection'] as any) = async (...params: any) => {
+      const conn = await makeConnection(...params);
       conn['_mediaHandler'].oniceconnectionstatechange = (state: string) => {
         if (state === 'checking') {
           start = Date.now();
@@ -82,7 +82,7 @@ maybeSkip('ICE Nomination', function() {
       return conn;
     };
 
-    device1.connect({ params: { To: identity2 } });
+    await device1.connect({ params: { To: identity2 } });
     const conn2 = await expectEvent('incoming', device2);
 
     conn2.accept();

--- a/tests/integration/mutableOptions.ts
+++ b/tests/integration/mutableOptions.ts
@@ -8,7 +8,7 @@ function waitFor(n: number, reject?: boolean) {
   return new Promise((res, rej) => setTimeout(reject ? rej : res, n));
 }
 
-describe('mutable options', function() {
+describe.only('mutable options', function() {
   let device: Device;
   let token: string;
 
@@ -27,12 +27,12 @@ describe('mutable options', function() {
   it('should update edge', async function() {
     this.timeout(10000);
 
-    device = new Device();
+    device = new Device(token, { edge: 'sydney' });
 
-    await device.register(token, { edge: 'sydney' });
+    await device.register();
     assert.equal(device.edge, 'sydney');
 
-    await device.register(token, { edge: 'ashburn' });
+    await device.updateOptions({ edge: 'ashburn' });
     assert.equal(device.edge, 'ashburn');
   });
 
@@ -58,8 +58,8 @@ describe('mutable options', function() {
       ] = await Promise.all(['caller', 'receiver'].map(async (n): Promise<[Device, string, string]> => {
         const id = `device-${n}-${timestamp}`;
         const t = generateAccessToken(id);
-        const dev = new Device();
-        await dev.register(t);
+        const dev = new Device(t);
+        await dev.register();
         return [dev, id, t];
       }));
 
@@ -67,7 +67,7 @@ describe('mutable options', function() {
         receiver.once(Device.EventName.Incoming, resolve);
       });
 
-      callerConnection = caller.connect({ params: { To: receiverId } });
+      callerConnection = await caller.connect({ params: { To: receiverId } });
       receiverConnection = await receiverConnPromise;
       receiverConnection.accept();
 
@@ -88,7 +88,7 @@ describe('mutable options', function() {
       const logSpy = sinon.spy();
       caller['_log'].warn = logSpy;
 
-      caller.setOptions({});
+      caller.updateOptions();
       assert.equal(logSpy.args.filter(
         ([message]) => message === 'Existing Device has ongoing connections; ignoring new options.',
       ).length, 1);
@@ -100,7 +100,7 @@ describe('mutable options', function() {
 
       callerConnection.disconnect();
 
-      caller.setOptions({});
+      caller.updateOptions();
       assert.equal(logSpy.args.filter(
         ([message]) => message === 'Existing Device has ongoing connections; ignoring new options.',
       ).length, 0);

--- a/tests/integration/mutableOptions.ts
+++ b/tests/integration/mutableOptions.ts
@@ -8,7 +8,7 @@ function waitFor(n: number, reject?: boolean) {
   return new Promise((res, rej) => setTimeout(reject ? rej : res, n));
 }
 
-describe.only('mutable options', function() {
+describe('mutable options', function() {
   let device: Device;
   let token: string;
 

--- a/tests/integration/opus.ts
+++ b/tests/integration/opus.ts
@@ -13,7 +13,7 @@ describe('Opus', function() {
   let device2: Device;
   let identity1: string;
   let identity2: string;
-  let options;
+  let options: any;
   let token1: string;
   let token2: string;
 
@@ -25,16 +25,16 @@ describe('Opus', function() {
     options = {
       codecPreferences: [Connection.Codec.Opus, Connection.Codec.PCMU],
     };
-    device1 = new Device(options);
-    device2 = new Device(options);
+    device1 = new Device(token1, options);
+    device2 = new Device(token2, options);
 
     const deviceReadyPromise = Promise.all([
-      expectEvent('ready', device1),
-      expectEvent('ready', device2),
+      expectEvent(Device.EventName.Registered, device1),
+      expectEvent(Device.EventName.Registered, device2),
     ]);
 
-    device1.register(token1);
-    device2.register(token2);
+    device1.register();
+    device2.register();
 
     return deviceReadyPromise;
   });

--- a/tests/integration/preflight.ts
+++ b/tests/integration/preflight.ts
@@ -40,9 +40,9 @@ describe('Preflight Test', function() {
 
     const receiverToken = generateAccessToken(receiverIdentity);
     callerToken = generateAccessToken(callerIdentity);
-    receiverDevice = new Device();
+    receiverDevice = new Device(receiverToken);
     receiverDevice.on('error', () => { });
-    await receiverDevice.register(receiverToken);
+    await receiverDevice.register();
   };
 
   const destroyDevices = () => {

--- a/tests/integration/reconnection.ts
+++ b/tests/integration/reconnection.ts
@@ -142,22 +142,21 @@ describe('Reconnection', function() {
       return runDockerCommand('resetNetwork');
     });
 
-    it('should trigger device.offline', async () => {
+    it('should trigger device.unregistered', async () => {
       await runDockerCommand('disconnectFromAllNetworks');
-      await waitFor(bindTestPerDevice((device: Device) => expectEvent('offline', device)), EVENT_TIMEOUT);
+      await waitFor(bindTestPerDevice((device: Device) => expectEvent(Device.EventName.Unregistered, device)), EVENT_TIMEOUT);
     });
 
     it('should disconnect call with error 31003', () => {
       return waitFor(bindTestPerConnection((conn: Connection) => Promise.all([
         expectEvent('disconnect', conn),
-        new Promise((resolve) => conn.once('error', (error) => error.code === 31003 && resolve()))
+        new Promise((resolve) => conn.once('error', (error) => error.code === 31003 && resolve())),
       ]).then(() =>  assert(conn.status() === Connection.State.Closed))), RTP_TIMEOUT);
     });
 
-    // TODO, does this change with lazy connection?
-    it.skip('should trigger device.registered after network resumes', async () => {
+    it('should trigger device.registered after network resumes', async () => {
       await runDockerCommand('resetNetwork');
-      await waitFor(bindTestPerDevice((device: Device) => expectEvent('registered', device)), EVENT_TIMEOUT);
+      await waitFor(bindTestPerDevice((device: Device) => expectEvent(Device.EventName.Registered, device)), EVENT_TIMEOUT);
     });
   });
 });

--- a/tests/integration/stirshaken.ts
+++ b/tests/integration/stirshaken.ts
@@ -20,16 +20,16 @@ describe('SHAKEN/STIR', function() {
     identity2 = 'aliceStir';
     token1 = generateAccessToken(identity1, undefined, (env as any).appSidStir);
     token2 = generateAccessToken(identity2, undefined, (env as any).appSidStir);
-    device1 = new Device();
-    device2 = new Device();
+    device1 = new Device(token1);
+    device2 = new Device(token2);
 
     const deviceReadyPromise = Promise.all([
-      expectEvent('ready', device1),
-      expectEvent('ready', device2),
+      expectEvent(Device.EventName.Registered, device1),
+      expectEvent(Device.EventName.Registered, device2),
     ]);
 
-    device1.register(token1);
-    device2.register(token2);
+    device1.register();
+    device2.register();
 
     return deviceReadyPromise;
   });

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -17,9 +17,8 @@ declare var root: any;
 
 const ClientCapability = require('twilio').jwt.ClientCapability;
 
-const NOT_INITIALIZED_ERROR = /Call Device.setup/;
+// tslint:disable max-classes-per-file only-arrow-functions no-empty
 
-/* tslint:disable-next-line */
 describe('Device', function() {
   let activeConnection: any;
   let audioHelper: any;
@@ -60,7 +59,7 @@ describe('Device', function() {
   beforeEach(() => {
     clock = sinon.useFakeTimers(Date.now());
     token = createToken('alice');
-    device = new Device(setupOptions);
+    device = new Device(token, setupOptions);
     device.on('error', () => { /* no-op */ });
   });
 
@@ -69,26 +68,26 @@ describe('Device', function() {
       Device['_isUnifiedPlanDefault'] = undefined;
 
       assert.equal(Device['_isUnifiedPlanDefault'], undefined);
-      const tempDev1 = new Device();
+      const tempDev1 = new Device(token);
       assert.notEqual(Device['_isUnifiedPlanDefault'], undefined);
 
       const isUnifiedPlan = Device['_isUnifiedPlanDefault'];
       Device['_isUnifiedPlanDefault'] = !isUnifiedPlan;
-      const tempDev2 = new Device();
+      const tempDev2 = new Device(token);
       assert.equal(Device['_isUnifiedPlanDefault'], !isUnifiedPlan);
     });
 
-    context('should always call setOptions', () => {
+    describe('should always call updateOptions', () => {
       it('when passed options', () => {
         stub = sinon.createStubInstance(Device);
-        Device.prototype.constructor.call(stub, setupOptions);
-        sinon.assert.calledOnce(stub.setOptions);
+        Device.prototype.constructor.call(stub, token, setupOptions);
+        sinon.assert.calledOnce(stub.updateOptions);
       });
 
       it('when not passed options', () => {
         stub = sinon.createStubInstance(Device);
-        Device.prototype.constructor.call(stub);
-        sinon.assert.calledOnce(stub.setOptions);
+        Device.prototype.constructor.call(stub, token);
+        sinon.assert.calledOnce(stub.updateOptions);
       });
     });
 
@@ -97,12 +96,12 @@ describe('Device', function() {
     });
 
     it('should set preflight to false if passed in as false', () => {
-      device = new Device({ ...setupOptions, preflight: false });
+      device = new Device(token, { ...setupOptions, preflight: false });
       assert.equal(device['_options'].preflight, false);
     });
 
     it('should set preflight to true if passed in as true', () => {
-      device = new Device({ ...setupOptions, preflight: true });
+      device = new Device(token, { ...setupOptions, preflight: true });
       assert.equal(device['_options'].preflight, true);
     });
 
@@ -111,292 +110,947 @@ describe('Device', function() {
     });
 
     it('should set forceAggressiveIceNomination to false if passed in as false', () => {
-      device = new Device({ ...setupOptions, forceAggressiveIceNomination: false });
+      device = new Device(token, { ...setupOptions, forceAggressiveIceNomination: false });
       assert.equal(device['_options'].forceAggressiveIceNomination, false);
     });
 
     it('should set forceAggressiveIceNomination to true if passed in as true', () => {
-      device = new Device({ ...setupOptions, forceAggressiveIceNomination: true });
+      device = new Device(token, { ...setupOptions, forceAggressiveIceNomination: true });
       assert.equal(device['_options'].forceAggressiveIceNomination, true);
+    });
+
+    it('should throw if the token is an invalid type', () => {
+      assert.throws(() => new Device(null as any), /Parameter "token" must be of type "string"./);
     });
   });
 
-  context('after Device is registered', () => {
-    beforeEach(async () => {
-      const registerPromise = device.register(token);
-      pstream.emit('ready');
-      await registerPromise;
+  describe('after Device is constructed', () => {
+    it('should create a publisher', () => {
+      assert(device['_publisher']);
     });
 
-    describe('.activeConnection', () => {
-      it('should return undefined if there are no Connections', () => {
-        assert.equal(device.activeConnection, undefined);
+    describe('after the Device has been connected to signaling', () => {
+      beforeEach(async () => {
+        const setupPromise = device['_setupStream']();
+        pstream.emit('ready');
+        await setupPromise;
       });
 
-      it('should return the active Connection if one exists', () => {
-        const conn = device.connect();
-        assert.equal(device.activeConnection, conn);
-        assert.equal(device.activeConnection, activeConnection);
-      });
-    });
+      describe('.activeConnection', () => {
+        it('should return "null" if there is no active Connection', () => {
+          assert.equal(device.activeConnection, null);
+        });
 
-    describe('.connect(params?, audioConstraints?, iceServers?)', () => {
-      it('should throw an error if there is already an active connection', () => {
-        device.connect();
-        assert.throws(() => device.connect(), /A Connection is already active/);
-      });
-
-      it('should call ignore on all existing connections', () => {
-        const connections: any[] = [];
-        for (let i = 0; i < 10; i++) {
-          connections.push({ ignore: sinon.spy() });
-        }
-        device['_connections'] = connections;
-        device.connect();
-        connections.forEach((conn: any) => sinon.assert.calledOnce(conn.incoming));
-        assert.equal(device.connections.length, 0);
+        it('should return the active Connection if one exists', async () => {
+          const conn = await device.connect();
+          assert.equal(device.activeConnection, conn);
+          assert.equal(device.activeConnection, activeConnection);
+        });
       });
 
-      it('should stop playing the incoming sound', () => {
-        const spy: any = { stop: sinon.spy() };
-        device['_soundcache'].set(Device.SoundName.Incoming, spy);
-        device.connect();
-        sinon.assert.calledOnce(spy.stop);
+      describe('.connect(params?, audioConstraints?, iceServers?)', () => {
+        let pStreamMock: EventEmitter & {
+          destroy: sinon.SinonSpy;
+          setToken: sinon.SinonSpy;
+        };
+        let PStream: sinon.SinonSpy;
+
+        beforeEach(async () => {
+          pStreamMock = new (class PStreamMock extends EventEmitter {
+            destroy = sinon.stub();
+            setToken = sinon.stub();
+          })();
+
+          PStream = sinon.stub().returns(pStreamMock);
+
+          device = new Device(token, {
+            ...setupOptions,
+            PStream,
+          });
+
+          const setupPromise = device['_setupStream']();
+          pStreamMock.emit('ready');
+          await setupPromise;
+        });
+
+        it('should reject if there is already an active connection', async () => {
+          await device.connect();
+          await assert.rejects(() => device.connect(), /A Connection is already active/);
+        });
+
+        it('should call ignore on all existing connections', async () => {
+          const connections: any[] = [];
+          for (let i = 0; i < 10; i++) {
+            connections.push({ ignore: sinon.spy() });
+          }
+          device['_connections'] = connections;
+          await device.connect();
+          connections.forEach((conn: any) => sinon.assert.calledOnce(conn.ignore));
+          assert.equal(device.connections.length, 0);
+        });
+
+        it('should not set up a signaling connection if unnecessary', async () => {
+          await device.connect();
+          sinon.assert.calledOnce(PStream);
+        });
+
+        it('should stop playing the incoming sound', async () => {
+          const spy: any = { stop: sinon.spy() };
+          device['_soundcache'].set(Device.SoundName.Incoming, spy);
+          await device.connect();
+          sinon.assert.calledOnce(spy.stop);
+        });
+
+        it('should return a Connection', async () => {
+          assert.equal(await device.connect(), activeConnection);
+        });
+
+        it('should set .activeConnection', async () => {
+          assert.equal(await device.connect(), device.activeConnection);
+        });
+
+        it('should play outgoing sound after accepted if enabled', async () => {
+          const spy: any = { play: sinon.spy() };
+          device['_soundcache'].set(Device.SoundName.Outgoing, spy);
+          await device.connect();
+          activeConnection._direction = 'OUTGOING';
+          activeConnection.emit('accept');
+          sinon.assert.calledOnce(spy.play);
+        });
       });
 
-      it('should return a Connection', () => {
-        assert.equal(device.connect(), activeConnection);
+      describe('.destroy()', () => {
+        it('should destroy .stream if one exists', () => {
+          device.destroy();
+          sinon.assert.calledOnce(pstream.destroy);
+        });
+
+        it('should stop sending registrations', () => {
+          pstream.register.resetHistory();
+
+          device.destroy();
+          pstream.emit('connected', { region: 'US_EAST_VIRGINIA' });
+          clock.tick(30000 + 1);
+          sinon.assert.notCalled(pstream.register);
+        });
+
+        it('should disconnect all connections', () => {
+          const disconnect = sinon.spy();
+          (device as any)['_connections'] = [
+            { disconnect },
+            { disconnect },
+          ];
+          device.destroy();
+          sinon.assert.calledTwice(disconnect);
+        });
+
+        it('should disconnect active connection', async () => {
+          const conn: any = await device.connect();
+          device.destroy();
+          sinon.assert.calledOnce(conn.disconnect);
+        });
       });
 
-      it('should set .activeConnection', () => {
-        assert.equal(device.connect(), device.activeConnection);
+      describe('.disconnectAll()', () => {
+        it('should clear device._connections', () => {
+          (device as any)['_connections'] = [
+            { disconnect: () => { } },
+            { disconnect: () => { } },
+          ];
+          device.disconnectAll();
+          assert.equal(device.connections.length, 0);
+        });
+
+        it('should call disconnect on all connections', () => {
+          const disconnect = sinon.spy();
+          (device as any)['_connections'] = [
+            { disconnect },
+            { disconnect },
+          ];
+          device.disconnectAll();
+          sinon.assert.calledTwice(disconnect);
+        });
+
+        it('should call disconnect on the active connection', async () => {
+          const conn: any = await device.connect();
+          device.disconnectAll();
+          sinon.assert.calledOnce(conn.disconnect);
+        });
       });
 
-      it('should play outgoing sound after accepted if enabled', () => {
-        const spy: any = { play: sinon.spy() };
-        device['_soundcache'].set(Device.SoundName.Outgoing, spy);
-        device.connect();
-        activeConnection._direction = 'OUTGOING';
-        activeConnection.emit('accept');
-        sinon.assert.calledOnce(spy.play);
-      });
-    });
+      describe('.edge', () => {
+        it(`should return 'null' if not connected`, () => {
+          assert.equal(device.edge, null);
+        });
 
-    describe('.destroy()', () => {
-      it('should destroy .stream', () => {
-        device.destroy();
-        sinon.assert.calledOnce(pstream.destroy);
-      });
+        // these unit tests will need to be changed for Phase 2 Regional
+        context('when the region is mapped to a known edge', () => {
+          Object.entries(regionShortcodes).forEach(([fullName, region]: [string, string]) => {
+            const preferredEdge = regionToEdge[region as Region];
+            it(`should return ${preferredEdge} for ${region}`, () => {
+              pstream.emit('connected', { region: fullName });
+              assert.equal(device.edge, preferredEdge);
+            });
+          });
+        });
 
-      it('should stop sending registrations', () => {
-        device.destroy();
-        pstream.emit('connected', { region: 'US_EAST_VIRGINIA' });
-        clock.tick(30000 + 1);
-        sinon.assert.notCalled(pstream.register);
-      });
-
-      it('should disconnect all connections', () => {
-        const disconnect = sinon.spy();
-        (device as any)['_connections'] = [
-          { disconnect },
-          { disconnect },
-        ];
-        device.destroy();
-        sinon.assert.calledTwice(disconnect);
-      });
-
-      it('should disconnect active connection', () => {
-        const connection = device.connect();
-        device.destroy();
-        sinon.assert.calledOnce((connection as any).disconnect);
-      });
-    });
-
-    describe('.disconnectAll()', () => {
-      it('should clear device._connections', () => {
-        (device as any)['_connections'] = [
-          { disconnect: () => { } },
-          { disconnect: () => { } },
-        ];
-        device.disconnectAll();
-        assert.equal(device.connections.length, 0);
-      });
-
-      it('should call disconnect on all connections', () => {
-        const disconnect = sinon.spy();
-        (device as any)['_connections'] = [
-          { disconnect },
-          { disconnect },
-        ];
-        device.disconnectAll();
-        sinon.assert.calledTwice(disconnect);
-      });
-
-      it('should call disconnect on the active connection', () => {
-        const connection = device.connect();
-        device.disconnectAll();
-        sinon.assert.calledOnce((connection as any).disconnect);
-      });
-    });
-
-    describe('.edge', () => {
-      it(`should return 'null' if not connected`, () => {
-        assert.equal(device.edge, null);
-      });
-
-      // these unit tests will need to be changed for Phase 2 Regional
-      context('when the region is mapped to a known edge', () => {
-        Object.entries(regionShortcodes).forEach(([fullName, region]: [string, string]) => {
-          const preferredEdge = regionToEdge[region as Region];
-          it(`should return ${preferredEdge} for ${region}`, () => {
-            pstream.emit('connected', { region: fullName });
-            assert.equal(device.edge, preferredEdge);
+        context('when the region is not mapped to a known edge', () => {
+          ['FOO_BAR', ''].forEach((name: string) => {
+            it(`should return the region string directly if it's '${name}'`, () => {
+              pstream.emit('connected', { region: name });
+              assert.equal(device['_region'], name);
+            });
           });
         });
       });
 
-      context('when the region is not mapped to a known edge', () => {
-        ['FOO_BAR', ''].forEach((name: string) => {
-          it(`should return the region string directly if it's '${name}'`, () => {
-            pstream.emit('connected', { region: name });
-            assert.equal(device['_region'], name);
+      describe('.register()', () => {
+        let pStreamMock: EventEmitter & {
+          destroy: sinon.SinonSpy;
+          register: sinon.SinonSpy;
+          setToken: sinon.SinonSpy;
+        };
+        let PStream: sinon.SinonSpy;
+
+        beforeEach(async () => {
+          pStreamMock = new (class PStreamMock extends EventEmitter {
+            destroy = sinon.stub();
+            register = sinon.stub();
+            setToken = sinon.stub();
+          })();
+
+          PStream = sinon.stub().returns(pStreamMock);
+
+          device = new Device(token, {
+            ...setupOptions,
+            PStream,
+          });
+
+          const setupPromise = device['_setupStream']();
+          pStreamMock.emit('ready');
+          await setupPromise;
+        });
+
+        it('should not set up a signaling connection if unnecessary', async () => {
+          await device.register();
+          sinon.assert.calledOnce(PStream);
+        });
+
+        it('should set state to "registered" immediately', async () => {
+          await device.register();
+          assert.equal(device.state, Device.State.Registered);
+        });
+
+        it('should send a register request with audio: true', async () => {
+          await device.register();
+          sinon.assert.calledOnce(pStreamMock.register);
+          sinon.assert.calledWith(pStreamMock.register, { audio: true });
+        });
+
+        it('should start the registration timer', async () => {
+          await device.register();
+          sinon.assert.calledOnce(pStreamMock.register);
+          await clock.tickAsync(30000 + 1);
+          sinon.assert.calledTwice(pStreamMock.register);
+        });
+      });
+
+      describe('.state', () => {
+        it('should return "registered" after registering', async () => {
+          await device.register();
+          assert.equal(device.state, Device.State.Registered);
+        });
+      });
+
+      describe('.unregister()', () => {
+        let pStreamMock: EventEmitter & {
+          destroy: sinon.SinonSpy;
+          register: sinon.SinonSpy;
+          setToken: sinon.SinonSpy;
+        };
+        let PStream: sinon.SinonSpy;
+
+        beforeEach(async () => {
+          pStreamMock = new (class PStreamMock extends EventEmitter {
+            destroy = sinon.stub();
+            register = sinon.stub();
+            setToken = sinon.stub();
+          })();
+
+          PStream = sinon.stub().returns(pStreamMock);
+
+          device = new Device(token, {
+            ...setupOptions,
+            PStream,
+          });
+
+          const regPromise = device.register();
+          pStreamMock.emit('ready');
+          await regPromise;
+
+        });
+
+        it('should send a register request with audio: false', async () => {
+          pStreamMock.register.resetHistory();
+          await device.unregister();
+          sinon.assert.calledOnce(pStreamMock.register);
+          sinon.assert.calledWith(pStreamMock.register, { audio: false });
+        });
+
+        it('should stop the registration timer', async () => {
+          pStreamMock.register.resetHistory();
+          await device.unregister();
+          sinon.assert.calledOnce(pStreamMock.register);
+          await clock.tickAsync(30000 + 1);
+          sinon.assert.calledOnce(pStreamMock.register);
+        });
+      });
+
+      describe('.updateOptions()', () => {
+        it('should set up an audio helper', () => {
+          const spy = device['_setupAudioHelper'] = sinon.spy(device['_setupAudioHelper']);
+          device.updateOptions({});
+          sinon.assert.calledOnce(spy);
+        });
+
+        it('should reconstruct an existing stream if necessary', async () => {
+          const regPromise = device.register();
+          pstream.emit('ready');
+          await regPromise;
+
+          const setupStreamSpy = device['_setupStream'] = sinon.spy(device['_setupStream']);
+          device.updateOptions({ edge: 'ashburn' });
+          sinon.assert.calledOnce(setupStreamSpy);
+        });
+
+        describe('log', () => {
+          let setDefaultLevelStub: any;
+
+          beforeEach(() => {
+            setDefaultLevelStub = sinon.stub();
+          });
+
+          Object.entries(LogLevels).forEach(([level, number]) => {
+            it(`should set log level to '${level}'`, () => {
+              device['_log'].setDefaultLevel = setDefaultLevelStub;
+              device.updateOptions({ logLevel: number });
+              sinon.assert.calledWith(setDefaultLevelStub, number);
+            });
+          });
+        });
+      });
+
+      describe('.updateToken()', () => {
+        const pStreamMock = new (class PStreamMock extends EventEmitter {
+          destroy = sinon.stub();
+          setToken = sinon.stub();
+        })();
+        const PStream = sinon.stub().returns(pStreamMock);
+
+        const publisherMock = new (class PublisherMock extends EventEmitter {
+          destroy = sinon.stub();
+          setToken = sinon.stub();
+        })();
+        const Publisher = sinon.stub().returns(publisherMock);
+
+        const options = {
+          ...setupOptions,
+          PStream,
+          Publisher,
+        };
+
+        beforeEach(() => {
+          pStreamMock.removeAllListeners();
+          publisherMock.removeAllListeners();
+
+          PStream.resetHistory();
+          Publisher.resetHistory();
+
+          device = new Device(token, options);
+        });
+
+        it('should update the tokens for an existing stream and publisher', () => {
+          device.register();
+
+          const newToken = 'foobar-token';
+
+          device.updateToken(newToken);
+
+          sinon.assert.calledOnce(pStreamMock.setToken);
+          sinon.assert.calledWith(pStreamMock.setToken, newToken);
+
+          sinon.assert.calledOnce(publisherMock.setToken);
+          sinon.assert.calledWith(publisherMock.setToken, newToken);
+        });
+      });
+
+      describe('on device change', () => {
+        it('should call _onInputDevicesChanges on the active Connection', async () => {
+          await device.connect();
+          const spy: SinonSpy = sinon.spy();
+          activeConnection['_mediaHandler'] = { _onInputDevicesChanged: spy };
+          device.audio && device.audio.emit('deviceChange', []);
+          sinon.assert.calledOnce(spy);
+        });
+      });
+
+      describe('on signaling.close', () => {
+        it('should set stream to null', () => {
+          pstream.emit('close');
+          assert.equal(device['_stream'], null);
+        });
+      });
+
+      describe('on signaling.connected', () => {
+        it('should update region', () => {
+          pstream.emit('connected', { region: 'EU_IRELAND' });
+          assert.equal(device['_region'], regionShortcodes.EU_IRELAND);
+        });
+      });
+
+      describe('on signaling.error', () => {
+        const twilioError = new GeneralErrors.UnknownError();
+
+        it('should not emit Device.error if payload.error is missing', () => {
+          device.emit = sinon.spy();
+          pstream.emit('error', { });
+          sinon.assert.notCalled(device.emit as any);
+        });
+
+        it('should emit Device.error without connection if payload.callsid is missing', () => {
+          device.emit = sinon.spy();
+          pstream.emit('error', { error: { twilioError } });
+          sinon.assert.calledOnce(device.emit as any);
+          sinon.assert.calledWith(device.emit as any, 'error', twilioError);
+        });
+
+        it('should emit Device.error with connection if payload.callsid is present', async () => {
+          pstream.emit('invite', { callsid: 'foo', sdp: 'bar' });
+          await clock.tickAsync(0);
+          const conn = device.connections[0];
+          conn.parameters = { CallSid: 'foo' };
+          device.emit = sinon.spy();
+          pstream.emit('error', { error: { twilioError }, callsid: 'foo' });
+          sinon.assert.calledOnce(device.emit as any);
+          sinon.assert.calledWith(device.emit as any, 'error', twilioError, conn);
+        });
+
+        it('should not stop registrations if code is not 31205', async () => {
+          await device.register();
+          pstream.emit('error', { error: { } });
+          pstream.register.reset();
+          await clock.tickAsync(30000 + 1);
+          sinon.assert.called(pstream.register);
+        });
+
+        it('should stop registrations if code is 31205', async () => {
+          await device.register();
+          pstream.emit('error', { error: { code: 31205 } });
+          pstream.register.reset();
+          await clock.tickAsync(30000 + 1);
+          sinon.assert.notCalled(pstream.register);
+        });
+
+        it('should emit Device.error if code is 31005', () => {
+          device.emit = sinon.spy();
+          pstream.emit('error', { error: { code: 31005 } });
+          sinon.assert.calledOnce(device.emit as any);
+          sinon.assert.calledWith(device.emit as any, 'error');
+          const errorObject = (device.emit as sinon.SinonSpy).getCall(0).args[1];
+          assert.equal(31005, errorObject.code);
+        });
+      });
+
+      describe('on signaling.invite', () => {
+        it('should not create a new connection if already on an active call', async () => {
+          await device.connect();
+          pstream.emit('invite', { callsid: 'foo', sdp: 'bar' });
+          await clock.tickAsync(0);
+          assert.equal(device.connections.length, 0);
+        });
+
+        it('should emit an error and not create a new connection if payload is missing callsid', () => {
+          device.emit = sinon.spy();
+          pstream.emit('invite', { sdp: 'bar' });
+          assert.equal(device.connections.length, 0);
+          sinon.assert.calledOnce(device.emit as any);
+          sinon.assert.calledWith(device.emit as any, 'error');
+        });
+
+        it('should emit an error and not create a new connection if payload is missing sdp', () => {
+          device.emit = sinon.spy();
+          pstream.emit('invite', { sdp: 'bar' });
+          assert.equal(device.connections.length, 0);
+          sinon.assert.calledOnce(device.emit as any);
+          sinon.assert.calledWith(device.emit as any, 'error');
+        });
+
+        context('if not on an active call and payload is valid', () => {
+          beforeEach(async () => {
+            pstream.emit('invite', { callsid: 'foo', sdp: 'bar', parameters: { Params: 'foo=bar' } });
+            await clock.tickAsync(0);
+          });
+
+          it('should not create a new connection if not on an active call and payload is valid', () => {
+            assert.equal(device.connections.length, 1);
+          });
+
+          it('should pass the custom parameters to the new connection', () => {
+            assert.deepEqual(connectOptions && connectOptions.twimlParams, { foo: 'bar' });
+          });
+        });
+
+        it('should play the incoming sound', async () => {
+          const spy = { play: sinon.spy() };
+          device['_soundcache'].set(Device.SoundName.Incoming, spy);
+          pstream.emit('invite', { callsid: 'foo', sdp: 'bar' });
+          await clock.tickAsync(0);
+          sinon.assert.calledOnce(spy.play);
+        });
+
+        context('when allowIncomingWhileBusy is true', () => {
+          beforeEach(async () => {
+            device = new Device(token, { ...setupOptions, allowIncomingWhileBusy: true });
+            const setupPromise = device['_setupStream']();
+            pstream.emit('ready');
+            await setupPromise;
+            await device.connect();
+          });
+
+          it('should create a new connection', async () => {
+            pstream.emit('invite', { callsid: 'foo', sdp: 'bar' });
+            await clock.tickAsync(0);
+            assert.equal(device.connections.length, 1);
+            assert.notEqual(device.connections[0], device.activeConnection);
+          });
+
+          it('should not play the incoming sound', async () => {
+            const spy = { play: sinon.spy() };
+            device['_soundcache'].set(Device.SoundName.Incoming, spy);
+            pstream.emit('invite', { callsid: 'foo', sdp: 'bar' });
+            await clock.tickAsync(0);
+            sinon.assert.notCalled(spy.play);
+          });
+        });
+      });
+
+      describe('on signaling.offline', () => {
+        it('should set "Device.state" to "Device.State.Unregistered"', () => {
+          pstream.emit('offline');
+          assert.equal(device.state, Device.State.Unregistered);
+        });
+
+        it(`should set Device edge to 'null'`, () => {
+          pstream.emit('offline');
+          assert.equal(device.edge, null);
+        });
+
+        it('should emit Device.EventName.Unregistered', () => {
+          device.emit = sinon.spy();
+          pstream.emit('offline');
+          sinon.assert.calledOnce(device.emit as any);
+          sinon.assert.calledWith(device.emit as any, Device.EventName.Unregistered);
+        });
+      });
+
+      // TODO, do we want to get rid of this?
+      describe.skip('on signaling.ready', () => {
+        it('should emit Device.ready', () => {
+          device.emit = sinon.spy();
+          pstream.emit('ready');
+          sinon.assert.calledOnce(device.emit as any);
+          sinon.assert.calledWith(device.emit as any, 'ready');
+        });
+      });
+
+      describe('on event subscriptions coming from connection', () => {
+        let connection: any;
+
+        beforeEach(async () => {
+          const incomingPromise = new Promise(resolve =>
+            device.once(Device.EventName.Incoming, () => {
+              device.connections[0].parameters = { };
+              connection = device.connections[0];
+              resolve();
+            }),
+          );
+
+          pstream.emit('invite', {
+            callsid: 'CA1234',
+            sdp: 'foobar',
+          });
+
+          await incomingPromise;
+        });
+
+        it('should emit device:connect asynchronously', () => {
+          const stub = sinon.stub();
+          device.on('connect', stub);
+          connection.emit('accept');
+
+          sinon.assert.notCalled(stub);
+          clock.tick(1);
+          sinon.assert.calledOnce(stub);
+        });
+
+        ['error', 'cancel', 'disconnect'].forEach(event => {
+          it(`should emit device:${event} asynchronously`, () => {
+            const stub = sinon.stub();
+            device.on(event, stub);
+            connection.emit(event);
+
+            sinon.assert.notCalled(stub);
+            clock.tick(1);
+            sinon.assert.calledOnce(stub);
+          });
+        });
+      });
+
+      describe('with a pending incoming call', () => {
+        beforeEach(async () => {
+          const incomingPromise = new Promise(resolve =>
+            device.once(Device.EventName.Incoming, () => {
+              device.emit = sinon.spy();
+              device.connections[0].parameters = { };
+              resolve();
+            }),
+          );
+
+          pstream.emit('invite', {
+            callsid: 'CA1234',
+            sdp: 'foobar',
+          });
+
+          await incomingPromise;
+        });
+
+        describe('on connection.accept', () => {
+          it('should should set the active connection', () => {
+            const conn = device.connections[0];
+            conn.emit('accept');
+            assert.equal(conn, device.activeConnection);
+          });
+
+          it('should should remove the connection', () => {
+            device.connections[0].emit('accept');
+            assert.equal(device.connections.length, 0);
+          });
+
+          it('should emit Device.connect', () => {
+            device.connections[0].emit('accept');
+            clock.tick(1);
+
+            sinon.assert.calledOnce(device.emit as any);
+            sinon.assert.calledWith(device.emit as any, 'connect');
+          });
+
+          it('should not play outgoing sound', () => {
+            const spy: any = { play: sinon.spy() };
+            device['_soundcache'].set(Device.SoundName.Outgoing, spy);
+            device.connections[0].emit('accept');
+            sinon.assert.notCalled(spy.play);
+          });
+        });
+
+        describe('on connection.error', () => {
+          it('should should remove the connection if closed', () => {
+            device.connections[0].status = () => ConnectionType.State.Closed;
+            device.connections[0].emit('error');
+            assert.equal(device.connections.length, 0);
+          });
+
+          it('should emit Device.error', () => {
+            device.connections[0].emit('error');
+            clock.tick(1);
+
+            sinon.assert.calledOnce(device.emit as any);
+            sinon.assert.calledWith(device.emit as any, 'error');
+          });
+        });
+
+        describe('on connection.transportClose', () => {
+          it('should remove the connection if the connection was pending', () => {
+            device.connections[0].status = () => ConnectionType.State.Pending;
+            device.connections[0].emit('transportClose');
+            assert.equal(device.connections.length, 0);
+          });
+          it('should not remove the connection if the connection was open', () => {
+            device.connections[0].status = () => ConnectionType.State.Open;
+            device.connections[0].emit('transportClose');
+            assert.equal(device.connections.length, 1);
+          });
+        });
+
+        describe('on connection.cancel', () => {
+          it('should emit Device.cancel', () => {
+            it('should should remove the connection', () => {
+              device.connections[0].emit('cancel');
+              assert.equal(device.connections.length, 0);
+            });
+
+            device.connections[0].emit('cancel');
+            clock.tick(1);
+
+            sinon.assert.calledOnce(device.emit as any);
+            sinon.assert.calledWith(device.emit as any, 'cancel');
+          });
+        });
+
+        describe('on connection.disconnect', () => {
+          it('should emit Device.disconnect', () => {
+            device.connections[0].emit('disconnect');
+            clock.tick(1);
+
+            sinon.assert.calledOnce(device.emit as any);
+            sinon.assert.calledWith(device.emit as any, 'disconnect');
+          });
+
+          it('should remove connection from activeDevice', () => {
+            const conn = device.connections[0];
+            conn.emit('accept');
+            assert.equal(typeof conn, 'object');
+            assert.equal(conn, device.activeConnection);
+
+            conn.emit('disconnect');
+            assert.equal(device.activeConnection, null);
+          });
+        });
+
+        describe('on connection.reject', () => {
+          it('should should remove the connection', () => {
+            device.connections[0].emit('reject');
+            assert.equal(device.connections.length, 0);
+          });
+        });
+      });
+
+      describe('Device.audio hooks', () => {
+        describe('updateInputStream', () => {
+          it('should reject if a connection is active and input stream is null', async () => {
+            await device.connect();
+
+            return updateInputStream(null).then(
+              () => { throw new Error('Expected rejection'); },
+              () => { });
+          });
+
+          it('should return a resolved Promise if there is no active connection', () => {
+            return updateInputStream(null);
+          });
+
+          it('should call the connection._setInputTracksFromStream', async () => {
+            const info = { id: 'default', label: 'default' };
+            await device.connect();
+            activeConnection._setInputTracksFromStream = sinon.spy(() => Promise.resolve());
+            return updateInputStream(info).then(() => {
+              sinon.assert.calledOnce(activeConnection._setInputTracksFromStream);
+              sinon.assert.calledWith(activeConnection._setInputTracksFromStream, info);
+            });
+          });
+        });
+
+        describe('updateSinkIds', () => {
+          context(`when type is 'speaker'`, () => {
+            it('should call setSinkIds on all sounds except incoming', () => {
+              const sinkIds = ['default'];
+              updateSinkIds('speaker', sinkIds);
+              Object.values(Device.SoundName)
+                .filter((name: Device.SoundName) => name !== Device.SoundName.Incoming)
+                .forEach((name: Device.SoundName) => {
+                  sinon.assert.calledOnce(sounds[name].setSinkIds);
+                  sinon.assert.calledWith(sounds[name].setSinkIds, sinkIds);
+                });
+            });
+
+            it('should call _setSinkIds on the active connection', async () => {
+              await device.connect();
+              const sinkIds = ['default'];
+              activeConnection._setSinkIds = sinon.spy(() => Promise.resolve());
+              updateSinkIds('speaker', sinkIds);
+              sinon.assert.calledOnce(activeConnection._setSinkIds);
+              sinon.assert.calledWith(activeConnection._setSinkIds, sinkIds);
+            });
+
+            context('if successful', () => {
+              let sinkIds: string[];
+              beforeEach(async () => {
+                await device.connect();
+                sinkIds = ['default'];
+                activeConnection._setSinkIds = sinon.spy(() => Promise.resolve())
+                return updateSinkIds('speaker', sinkIds);
+              });
+
+              it('should publish a speaker-devices-set event', () => {
+                sinon.assert.calledOnce(publisher.info);
+                sinon.assert.calledWith(publisher.info, 'audio', 'speaker-devices-set',
+                  { audio_device_ids: sinkIds });
+              });
+            });
+
+            context('if unsuccessful', () => {
+              let sinkIds: string[];
+              beforeEach(async () => {
+                await device.connect();
+                sinkIds = ['default'];
+                activeConnection._setSinkIds = sinon.spy(() => Promise.reject(new Error('foo')));
+                return updateSinkIds('speaker', sinkIds).then(
+                  () => { throw Error('Expected a rejection') },
+                  () => Promise.resolve());
+              });
+
+              it('should publish a speaker-devices-set event', () => {
+                sinon.assert.calledOnce(publisher.error);
+                sinon.assert.calledWith(publisher.error, 'audio', 'speaker-devices-set-failed',
+                  { audio_device_ids: sinkIds, message: 'foo' });
+              });
+            });
+          });
+
+          context(`when type is 'ringtone'`, () => {
+            it('should call setSinkIds on incoming', () => {
+              const sinkIds = ['default'];
+              updateSinkIds('ringtone', sinkIds);
+              sinon.assert.calledOnce(sounds[Device.SoundName.Incoming].setSinkIds);
+              sinon.assert.calledWith(sounds[Device.SoundName.Incoming].setSinkIds, sinkIds);
+            });
+
+            context('if successful', () => {
+              let sinkIds: string[];
+              beforeEach(async () => {
+                await device.connect();
+                sinkIds = ['default'];
+                activeConnection._setSinkIds = sinon.spy(() => Promise.resolve())
+                return updateSinkIds('ringtone', sinkIds);
+              });
+
+              it('should publish a ringtone-devices-set event', () => {
+                sinon.assert.calledOnce(publisher.info);
+                sinon.assert.calledWith(publisher.info, 'audio', 'ringtone-devices-set',
+                  { audio_device_ids: sinkIds });
+              });
+            });
           });
         });
       });
     });
 
-    describe('.listen()', () => {
-      it('should send a register request with audio: true', () => {
-        device.listen(true);
-        sinon.assert.calledOnce(pstream.register);
-        sinon.assert.calledWith(pstream.register, { audio: true });
-      });
-
-      it('should send a register request with audio: false', () => {
-        device.listen(false);
-        sinon.assert.calledOnce(pstream.register);
-        sinon.assert.calledWith(pstream.register, { audio: false });
-      });
-
-      it('should start the registration timer', () => {
-        device.listen(true);
-        sinon.assert.calledOnce(pstream.register);
-        clock.tick(30000 + 1);
-        sinon.assert.calledTwice(pstream.register);
-      });
-
-      it('should stop the registration timer', () => {
-        device.listen(false);
-        sinon.assert.calledOnce(pstream.register);
-        clock.tick(30000 + 1);
-        sinon.assert.calledOnce(pstream.register);
-      });
-    });
-
-    describe('.register()', () => {
-      const PStreamMock: any = new (class PStreamMock extends EventEmitter {
-        destroy = sinon.stub();
-        setToken = sinon.stub();
-      })();
-      const PStream = sinon.stub().returns(PStreamMock);
-
-      const PublisherStubs = {
-        disable: sinon.stub(),
-        on: sinon.stub(),
-        setToken: sinon.stub(),
+    describe('before the Device has been connected to signaling', () => {
+      let pStreamMock: EventEmitter & {
+        destroy: sinon.SinonSpy;
+        setToken: sinon.SinonSpy;
       };
-      const Publisher = sinon.stub().returns(PublisherStubs);
-
-      const options = { ...setupOptions, PStream, Publisher };
+      let PStream: sinon.SinonSpy;
 
       beforeEach(() => {
-        device = new Device(options);
-        PStreamMock.removeAllListeners();
-        PStream.resetHistory();
-        Publisher.resetHistory();
+        pStreamMock = new (class PStreamMock extends EventEmitter {
+          destroy = sinon.stub();
+          setToken = sinon.stub();
+        })();
+
+        PStream = sinon.stub().returns(pStreamMock);
+
+        device = new Device(token, {
+          ...setupOptions,
+          PStream,
+        });
       });
 
-      it('should return a Promise-like', () => {
-        const devicePromise = device.register(token);
-        assert(typeof devicePromise.then === 'function');
-        assert(typeof devicePromise.catch === 'function');
-        assert(typeof devicePromise.finally === 'function');
+      it('should lazy create a signaling connection', () => {
+        assert.equal(device['_stream'], null);
       });
 
-      it('should resolve with the device', async () => {
-        const devicePromise = device.register(token);
-        PStreamMock.emit('ready');
-        const resolvedDevice = await devicePromise;
-        assert(resolvedDevice === device);
+      describe('.connect(params?, audioConstraints?, iceServers?)', () => {
+        it('should set up a signaling connection if necessary', () => {
+          device.connect();
+          sinon.assert.calledOnce(PStream);
+          sinon.assert.calledWith(PStream, token);
+        });
+
+        it('should not set the active connection until the stream resolves', async () => {
+          const connectPromise = device.connect();
+          assert.equal(device.activeConnection, null);
+          pStreamMock.emit('ready');
+          await connectPromise;
+          assert(device.activeConnection);
+        });
       });
 
-      it('should create a new stream and publisher', () => {
-        device.register(token);
+      describe('.register()', () => {
+        const pStreamMock = new (class PStreamMock extends EventEmitter {
+          destroy = sinon.stub();
+          register = sinon.stub();
+          setToken = sinon.stub();
+        })();
+        const PStream = sinon.stub().returns(pStreamMock);
 
-        sinon.assert.calledOnce(PStream);
-        sinon.assert.calledWith(PStream, token);
+        const options = {
+          ...setupOptions,
+          PStream,
+        };
 
-        sinon.assert.calledOnce(Publisher);
-        sinon.assert.calledWith(Publisher, 'twilio-js-sdk', token);
+        beforeEach(() => {
+          device = new Device(token, options);
+
+          PStream.resetHistory();
+        });
+
+        it('should set up a signaling connection if necessary', () => {
+          device.register();
+          sinon.assert.calledOnce(PStream);
+          sinon.assert.calledWith(PStream, token);
+        });
+
+        it('should set state to "registering" until the stream resolves', () => {
+          device.register();
+          assert.equal(device.state, Device.State.Registering);
+        });
+
+        it('should set state to "registered" after the stream resolves', async () => {
+          const regPromise = device.register();
+          pStreamMock.emit('ready');
+          await regPromise;
+          assert.equal(device.state, Device.State.Registered);
+        });
       });
 
-      it('should update an existing stream and publisher', () => {
-        device.register(token);
-
-        PStream.resetHistory();
-        Publisher.resetHistory();
-
-        device.register(token);
-
-        sinon.assert.notCalled(PStream);
-        sinon.assert.notCalled(Publisher);
-
-        sinon.assert.calledOnce(PStreamMock.setToken);
-        sinon.assert.calledWith(PStreamMock.setToken, token);
-
-        sinon.assert.calledOnce(PublisherStubs.setToken);
-        sinon.assert.calledWith(PublisherStubs.setToken, token);
+      describe('.updateToken()', () => {
+        it('should set the token', () => {
+          const newToken = 'foobar-token';
+          device.updateToken(newToken);
+          assert.equal(device.token, newToken);
+        });
       });
+    });
 
-      it('should reconstruct an existing stream if necessary', () => {
-        const streamSpy = device['_setupStream'] = sinon.spy();
+    describe('when creating a signaling connection', () => {
+      let pStreamMock: EventEmitter & {
+        destroy: sinon.SinonSpy;
+        register: sinon.SinonSpy;
+        setToken: sinon.SinonSpy;
+      };
+      let PStream: sinon.SinonSpy;
+      let options: any;
 
-        device.register(token, { edge: 'ashburn' });
-
-        sinon.assert.calledOnce(streamSpy);
-      });
-
-      it('should reconstruct an existing publisher if necessary', () => {
-        const publisherSpy = device['_setupPublisher'] = sinon.spy();
-
-        device.register(token, { appName: 'foo' });
-
-        sinon.assert.calledOnce(publisherSpy);
-      });
-
-      it('should not reconstruct an existing stream if unnecessary', () => {
-        device.register(token);
-
-        const streamSpy = device['_setupStream'] = sinon.spy();
-
-        device.register(token);
-
-        sinon.assert.notCalled(streamSpy);
-      });
-
-      it('should not reconstruct an existing publisher if unnecessary', () => {
-        device.register(token);
-
-        const publisherSpy = device['_setupPublisher'] = sinon.spy();
-
-        device.register(token);
-
-        sinon.assert.notCalled(publisherSpy);
+      beforeEach(() => {
+        pStreamMock = new (class PStreamMock extends EventEmitter {
+          destroy = sinon.stub();
+          register = sinon.stub();
+          setToken = sinon.stub();
+        })();
+        PStream = sinon.stub().returns(pStreamMock);
+        options = {
+          ...setupOptions,
+          PStream,
+        };
       });
 
       describe('should use chunderw regardless', () => {
-        it('when it is a string', () => {
-          device.register(token, { chunderw: 'foo' } as any);
+        it('when it is a string', async () => {
+          device = new Device(token, { ...options, chunderw: 'foo' });
+
+          const setupPromise = device['_setupStream']();
+          pStreamMock.emit('ready');
+          await setupPromise;
 
           sinon.assert.calledOnce(PStream);
           sinon.assert.calledWithExactly(PStream,
@@ -404,8 +1058,12 @@ describe('Device', function() {
             { backoffMaxMs: undefined });
         });
 
-        it('when it is an array', () => {
-          device.register(token, { chunderw: ['foo', 'bar'] } as any);
+        it('when it is an array', async () => {
+          device = new Device(token, { ...options, chunderw: ['foo', 'bar'] });
+
+          const setupPromise = device['_setupStream']();
+          pStreamMock.emit('ready');
+          await setupPromise;
 
           sinon.assert.calledOnce(PStream);
           sinon.assert.calledWithExactly(PStream,
@@ -414,12 +1072,12 @@ describe('Device', function() {
         });
       });
 
-      it('should use default chunder uri if no region or edge is passed in', () => {
-        device.register(token, { edge: 'singapore' });
+      it('should use default chunder uri if no region or edge is passed in', async () => {
+        device = new Device(token, options);
 
-        PStream.resetHistory();
-
-        device.register(token);
+        const setupPromise = device['_setupStream']();
+        pStreamMock.emit('ready');
+        await setupPromise;
 
         sinon.assert.calledOnce(PStream);
         sinon.assert.calledWithExactly(PStream,
@@ -427,8 +1085,12 @@ describe('Device', function() {
           { backoffMaxMs: undefined });
       });
 
-      it('should use correct edge if only one is supplied', () => {
-        device.register(token, { edge: 'singapore' });
+      it('should use correct edge if only one is supplied', async () => {
+        device = new Device(token, { ...options, edge: 'singapore' });
+
+        const setupPromise = device['_setupStream']();
+        pStreamMock.emit('ready');
+        await setupPromise;
 
         sinon.assert.calledOnce(PStream);
         sinon.assert.calledWithExactly(PStream,
@@ -436,8 +1098,12 @@ describe('Device', function() {
           { backoffMaxMs: undefined });
       });
 
-      it('should use correct edges if more than one is supplied', () => {
-        device.register(token, { edge: ['singapore', 'sydney'] });
+      it('should use correct edges if more than one is supplied', async () => {
+        device = new Device(token, { ...options, edge: ['singapore', 'sydney'] });
+
+        const setupPromise = device['_setupStream']();
+        pStreamMock.emit('ready');
+        await setupPromise;
 
         sinon.assert.calledOnce(PStream);
         sinon.assert.calledWithExactly(PStream, token, [
@@ -445,541 +1111,108 @@ describe('Device', function() {
           'wss://chunderw-vpc-gll-au1.twilio.com/signal',
         ], { backoffMaxMs: undefined });
       });
-    });
 
-    describe('.setOptions()', () => {
-      it('should set up an audio helper', () => {
-        const spy = device['_setupAudioHelper'] = sinon.spy(device['_setupAudioHelper']);
-        device.setOptions({});
-        sinon.assert.calledOnce(spy);
-      });
-
-      describe('log', () => {
-        let setDefaultLevelStub: any;
-
-        beforeEach(() => {
-          setDefaultLevelStub = sinon.stub();
-        });
-
-        Object.entries(LogLevels).forEach(([level, number]) => {
-          it(`should set log level to '${level}'`, () => {
-            device['_log'].setDefaultLevel = setDefaultLevelStub;
-            device.setOptions({ logLevel: number });
-            sinon.assert.calledWith(setDefaultLevelStub, number);
+      describe('.updateOptions()', () => {
+        it('should not create a stream', async () => {
+          const setupSpy = device['_setupStream'] = sinon.spy(device['_setupStream']);
+          device.updateOptions();
+          await new Promise(resolve => {
+            sinon.assert.notCalled(setupSpy);
+            resolve();
           });
         });
       });
     });
 
-    describe('._setupAudioHelper()', () => {
-      it('should destroy an existing audio helper', () => {
-        const spy = device['_destroyAudioHelper'] = sinon.spy(device['_destroyAudioHelper']);
-        device.setOptions({});
-        sinon.assert.calledOnce(spy);
-      });
-    });
+    describe('signaling agnostic', () => {
+      let pStreamMock: EventEmitter & {
+        destroy: sinon.SinonSpy;
+        register: sinon.SinonSpy;
+        setToken: sinon.SinonSpy;
+      };
+      let PStream: sinon.SinonSpy;
+      let options: any;
 
-    describe('.status()', () => {
-      it('should return offline before registering', () => {
-        device = new Device(setupOptions);
-        assert.equal(device.status(), Device.Status.Offline);
-      });
-    });
+      [{
+        afterEachHook: () => async () => {
+          sinon.assert.calledOnce(PStream);
+        },
+        beforeEachHook: () => async () => {
+          pStreamMock = new (class PStreamMock extends EventEmitter {
+            destroy = sinon.stub();
+            register = sinon.stub();
+            setToken = sinon.stub();
+          })();
+          PStream = sinon.stub().returns(pStreamMock);
+          options = {
+            ...setupOptions,
+            PStream,
+          };
+          device = new Device(token, options);
+          const setupPromise = device['_setupStream']();
+          pStreamMock.emit('ready');
+          await setupPromise;
+        },
+        title: 'signaling connected',
+      }, {
+        afterEachHook: async () => {},
+        beforeEachHook: async () => {
+          options = {
+            ...setupOptions,
+          };
+        },
+        title: 'signaling not connected',
+      }].forEach(({ afterEachHook, beforeEachHook, title }) => {
+        describe(title, () => {
+          beforeEach(beforeEachHook);
 
-    describe('on device change', () => {
-      it('should publish a device-change event', () => {
-        device.audio && device.audio.emit('deviceChange', [{ deviceId: 'foo' }]);
-        sinon.assert.calledOnce(publisher.info);
-        sinon.assert.calledWith(publisher.info, 'audio', 'device-change', {
-          lost_active_device_ids: ['foo']
-        });
-      });
+          afterEach(afterEachHook);
 
-      it('should call _onInputDevicesChanges on the active Connection', () => {
-        device.connect();
-        const spy: SinonSpy = sinon.spy();
-        activeConnection['_mediaHandler'] = { _onInputDevicesChanged: spy };
-        device.audio && device.audio.emit('deviceChange', []);
-        sinon.assert.calledOnce(spy);
-      });
-    });
-
-    describe('on Device.error', () => {
-      it('should never throw uncaught', () => {
-        const noop = () => { };
-
-        device.emit('error');
-        device.addListener(Device.EventName.Error, noop);
-        device.emit('error');
-        device.removeListener(Device.EventName.Error, noop);
-        device.emit('error');
-      });
-    });
-
-    describe('createDefaultPayload', () => {
-      xit('should be tested', () => {
-        // This should be moved somewhere that it can be tested. This is currently:
-        // A) Internal to Device where it can't easily be tested and
-        // B) Reaching into Connection, causing a weird coupling.
-      });
-    });
-
-    describe('on signaling.close', () => {
-      it('should set stream to null', () => {
-        pstream.emit('close');
-        assert.equal(device['_stream'], null);
-      });
-    });
-
-    describe('on signaling.connected', () => {
-      it('should update region', () => {
-        pstream.emit('connected', { region: 'EU_IRELAND' });
-        assert.equal(device['_region'], regionShortcodes.EU_IRELAND);
-      });
-
-      it('should send a register request with audio: true', () => {
-        pstream.emit('connected', { region: 'EU_IRELAND' });
-        sinon.assert.calledOnce(pstream.register);
-        sinon.assert.calledWith(pstream.register, { audio: true });
-      });
-
-      it('should start the registration timer', () => {
-        pstream.emit('connected', { region: 'EU_IRELAND' });
-        sinon.assert.calledOnce(pstream.register);
-        clock.tick(30000 + 1);
-        sinon.assert.calledTwice(pstream.register);
-      });
-    });
-
-    describe('on signaling.error', () => {
-      const twilioError = new GeneralErrors.UnknownError();
-
-      it('should not emit Device.error if payload.error is missing', () => {
-        device.emit = sinon.spy();
-        pstream.emit('error', { });
-        sinon.assert.notCalled(device.emit as any);
-      });
-
-      it('should emit Device.error without connection if payload.callsid is missing', () => {
-        device.emit = sinon.spy();
-        pstream.emit('error', { error: { twilioError } });
-        sinon.assert.calledOnce(device.emit as any);
-        sinon.assert.calledWith(device.emit as any, 'error', twilioError);
-      });
-
-      it('should emit Device.error with connection if payload.callsid is present', () => {
-        pstream.emit('invite', { callsid: 'foo', sdp: 'bar' });
-        const conn = device.connections[0];
-        conn.parameters = { CallSid: 'foo' };
-        device.emit = sinon.spy();
-        pstream.emit('error', { error: { twilioError }, callsid: 'foo' });
-        sinon.assert.calledOnce(device.emit as any);
-        sinon.assert.calledWith(device.emit as any, 'error', twilioError, conn);
-      });
-
-      it('should not stop registrations if code is not 31205', () => {
-        device.listen(true);
-        pstream.emit('error', { error: { } });
-        pstream.register.reset();
-        clock.tick(30000 + 1);
-        sinon.assert.called(pstream.register);
-      });
-
-      it('should stop registrations if code is 31205', () => {
-        device.listen(true);
-        pstream.emit('error', { error: { code: 31205 } });
-        pstream.register.reset();
-        clock.tick(30000 + 1);
-        sinon.assert.notCalled(pstream.register);
-      });
-
-      it('should emit Device.error if code is 31005', () => {
-        device.emit = sinon.spy();
-        pstream.emit('error', { error: { code: 31005 } });
-        sinon.assert.calledOnce(device.emit as any);
-        sinon.assert.calledWith(device.emit as any, 'error');
-        const errorObject = (device.emit as sinon.SinonSpy).getCall(0).args[1];
-        assert.equal(31005, errorObject.code);
-      });
-    });
-
-    describe('on signaling.invite', () => {
-      it('should not create a new connection if already on an active call', () => {
-        device.connect();
-        pstream.emit('invite', { callsid: 'foo', sdp: 'bar' });
-        assert.equal(device.connections.length, 0);
-      });
-
-      it('should emit an error and not create a new connection if payload is missing callsid', () => {
-        device.emit = sinon.spy();
-        pstream.emit('invite', { sdp: 'bar' });
-        assert.equal(device.connections.length, 0);
-        sinon.assert.calledOnce(device.emit as any);
-        sinon.assert.calledWith(device.emit as any, 'error');
-      });
-
-      it('should emit an error and not create a new connection if payload is missing sdp', () => {
-        device.emit = sinon.spy();
-        pstream.emit('invite', { sdp: 'bar' });
-        assert.equal(device.connections.length, 0);
-        sinon.assert.calledOnce(device.emit as any);
-        sinon.assert.calledWith(device.emit as any, 'error');
-      });
-
-      context('if not on an active call and payload is valid', () => {
-        beforeEach(() => {
-          pstream.emit('invite', { callsid: 'foo', sdp: 'bar', parameters: { Params: 'foo=bar' } });
-        });
-
-        it('should not create a new connection if not on an active call and payload is valid', () => {
-          assert.equal(device.connections.length, 1);
-        });
-
-        it('should pass the custom parameters to the new connection', () => {
-          assert.deepEqual(connectOptions && connectOptions.twimlParams, { foo: 'bar' });
-        });
-      });
-
-      it('should play the incoming sound', () => {
-        const spy = { play: sinon.spy() };
-        device['_soundcache'].set(Device.SoundName.Incoming, spy);
-        pstream.emit('invite', { callsid: 'foo', sdp: 'bar' });
-        sinon.assert.calledOnce(spy.play);
-      });
-
-      context('when allowIncomingWhileBusy is true', () => {
-        beforeEach(async () => {
-          device = new Device({ ...setupOptions, allowIncomingWhileBusy: true });
-          const registerPromise = device.register(token);
-          pstream.emit('ready');
-          await registerPromise;
-          device.connect();
-        });
-
-        it('should create a new connection', () => {
-          pstream.emit('invite', { callsid: 'foo', sdp: 'bar' });
-          assert.equal(device.connections.length, 1);
-          assert.notEqual(device.connections[0], device.activeConnection);
-        });
-
-        it('should not play the incoming sound', () => {
-          const spy = { play: sinon.spy() };
-          device['_soundcache'].set(Device.SoundName.Incoming, spy);
-          pstream.emit('invite', { callsid: 'foo', sdp: 'bar' });
-          sinon.assert.notCalled(spy.play);
-        });
-      });
-    });
-
-    describe('on signaling.offline', () => {
-      it('should set Device.status() to Device.Status.Offline', () => {
-        pstream.emit('offline');
-        assert.equal(device.status(), Device.Status.Offline);
-      });
-
-      it(`should set Device edge to 'null'`, () => {
-        pstream.emit('offline');
-        assert.equal(device.edge, null);
-      });
-
-      it('should emit Device.offline', () => {
-        device.emit = sinon.spy();
-        pstream.emit('offline');
-        sinon.assert.calledOnce(device.emit as any);
-        sinon.assert.calledWith(device.emit as any, 'offline');
-      });
-    });
-
-    describe('on signaling.ready', () => {
-      it('should set Device.status() to Device.Status.Ready if currently Offline', () => {
-        pstream.emit('ready');
-        assert.equal(device.status(), Device.Status.Ready);
-      });
-
-      it('should not change Device.status() if currently Busy', () => {
-        device.connect();
-        pstream.emit('ready');
-        assert.equal(device.status(), Device.Status.Busy);
-      });
-
-      it('should emit Device.offline', () => {
-        device.emit = sinon.spy();
-        pstream.emit('ready');
-        sinon.assert.calledOnce(device.emit as any);
-        sinon.assert.calledWith(device.emit as any, 'ready');
-      });
-    });
-
-    describe('on unload or pagehide', () => {
-      it('should call destroy once on pagehide', () => {
-        stub = sinon.createStubInstance(Device);
-        Device.prototype.constructor.call(stub);
-        root.window.dispatchEvent('pagehide');
-        sinon.assert.calledOnce(stub.destroy);
-      });
-
-      it('should call destroy once on unload', () => {
-        stub = sinon.createStubInstance(Device);
-        Device.prototype.constructor.call(stub);
-        root.window.dispatchEvent('unload');
-        sinon.assert.calledOnce(stub.destroy);
-      });
-    });
-
-    describe('on event subscriptions coming from connection', () => {
-      let connection: any;
-
-      beforeEach((done: Function) => {
-        device.once(Device.EventName.Incoming, () => {
-          device.connections[0].parameters = { };
-          connection = device.connections[0];
-          done();
-        });
-        pstream.emit('invite', {
-          callsid: 'CA1234',
-          sdp: 'foobar',
-        });
-      });
-
-      it('should emit device:connect asynchronously', () => {
-        const stub = sinon.stub();
-        device.on('connect', stub);
-        connection.emit('accept');
-
-        sinon.assert.notCalled(stub);
-        clock.tick(1);
-        sinon.assert.calledOnce(stub);
-      });
-
-      ['error', 'cancel', 'disconnect'].forEach(event => {
-        it(`should emit device:${event} asynchronously`, () => {
-          const stub = sinon.stub();
-          device.on(event, stub);
-          connection.emit(event);
-
-          sinon.assert.notCalled(stub);
-          clock.tick(1);
-          sinon.assert.calledOnce(stub);
-        });
-      });
-    });
-
-    context('with a pending incoming call', () => {
-      beforeEach((done: Function) => {
-        device.once(Device.EventName.Incoming, () => {
-          device.emit = sinon.spy();
-          device.connections[0].parameters = { };
-          done();
-        });
-
-        pstream.emit('invite', {
-          callsid: 'CA1234',
-          sdp: 'foobar',
-        });
-      });
-
-      describe('on connection.accept', () => {
-        it('should should set the active connection', () => {
-          const conn = device.connections[0];
-          conn.emit('accept');
-          assert.equal(conn, device.activeConnection);
-        });
-
-        it('should should remove the connection', () => {
-          device.connections[0].emit('accept');
-          assert.equal(device.connections.length, 0);
-        });
-
-        it('should emit Device.connect', () => {
-          device.connections[0].emit('accept');
-          clock.tick(1);
-
-          sinon.assert.calledOnce(device.emit as any);
-          sinon.assert.calledWith(device.emit as any, 'connect');
-        });
-
-        it('should not play outgoing sound', () => {
-          const spy: any = { play: sinon.spy() };
-          device['_soundcache'].set(Device.SoundName.Outgoing, spy);
-          device.connections[0].emit('accept');
-          sinon.assert.notCalled(spy.play);
-        });
-      });
-
-      describe('on connection.error', () => {
-        it('should should remove the connection if closed', () => {
-          device.connections[0].status = () => ConnectionType.State.Closed;
-          device.connections[0].emit('error');
-          assert.equal(device.connections.length, 0);
-        });
-
-        it('should emit Device.error', () => {
-          device.connections[0].emit('error');
-          clock.tick(1);
-
-          sinon.assert.calledOnce(device.emit as any);
-          sinon.assert.calledWith(device.emit as any, 'error');
-        });
-      });
-
-      describe('on connection.transportClose', () => {
-        it('should remove the connection if the connection was pending', () => {
-          device.connections[0].status = () => ConnectionType.State.Pending;
-          device.connections[0].emit('transportClose');
-          assert.equal(device.connections.length, 0);
-        });
-        it('should not remove the connection if the connection was open', () => {
-          device.connections[0].status = () => ConnectionType.State.Open;
-          device.connections[0].emit('transportClose');
-          assert.equal(device.connections.length, 1);
-        });
-      });
-
-      describe('on connection.cancel', () => {
-        it('should emit Device.cancel', () => {
-          it('should should remove the connection', () => {
-            device.connections[0].emit('cancel');
-            assert.equal(device.connections.length, 0);
+          describe('._setupAudioHelper()', () => {
+            it('should destroy an existing audio helper', () => {
+              const spy = device['_destroyAudioHelper'] = sinon.spy(device['_destroyAudioHelper']);
+              device['_setupAudioHelper']();
+              sinon.assert.calledOnce(spy);
+            });
           });
 
-          device.connections[0].emit('cancel');
-          clock.tick(1);
+          describe('.state', () => {
+            it('should return "unregistered" before registering', () => {
+              assert.equal(device.state, Device.State.Unregistered);
+            });
+          });
 
-          sinon.assert.calledOnce(device.emit as any);
-          sinon.assert.calledWith(device.emit as any, 'cancel');
-        });
-      });
-
-      describe('on connection.disconnect', () => {
-        it('should emit Device.disconnect', () => {
-          device.connections[0].emit('disconnect');
-          clock.tick(1);
-
-          sinon.assert.calledOnce(device.emit as any);
-          sinon.assert.calledWith(device.emit as any, 'disconnect');
-        });
-
-        it('should remove connection from activeDevice', () => {
-          const conn = device.connections[0];
-          conn.emit('accept');
-          assert.equal(typeof conn, 'object');
-          assert.equal(conn, device.activeConnection);
-
-          conn.emit('disconnect');
-          assert.equal(device.activeConnection, null);
-        });
-      });
-
-      describe('on connection.reject', () => {
-        it('should should remove the connection', () => {
-          device.connections[0].emit('reject');
-          assert.equal(device.connections.length, 0);
-        });
-      });
-    });
-
-    describe('Device.audio hooks', () => {
-      describe('updateInputStream', () => {
-        it('should reject if a connection is active and input stream is null', () => {
-          device.connect();
-          return updateInputStream(null).then(
-            () => { throw new Error('Expected rejection'); },
-            () => { });
-        });
-
-        it('should return a resolved Promise if there is no active connection', () => {
-          return updateInputStream(null);
-        });
-
-        it('should call the connection._setInputTracksFromStream', () => {
-          const info = { id: 'default', label: 'default' };
-          device.connect();
-          activeConnection._setInputTracksFromStream = sinon.spy(() => Promise.resolve());
-          return updateInputStream(info).then(() => {
-            sinon.assert.calledOnce(activeConnection._setInputTracksFromStream);
-            sinon.assert.calledWith(activeConnection._setInputTracksFromStream, info);
-          })
-        });
-      });
-
-      describe('updateSinkIds', () => {
-        context(`when type is 'speaker'`, () => {
-          it('should call setSinkIds on all sounds except incoming', () => {
-            const sinkIds = ['default'];
-            updateSinkIds('speaker', sinkIds);
-            Object.values(Device.SoundName)
-              .filter((name: Device.SoundName) => name !== Device.SoundName.Incoming)
-              .forEach((name: Device.SoundName) => {
-                sinon.assert.calledOnce(sounds[name].setSinkIds);
-                sinon.assert.calledWith(sounds[name].setSinkIds, sinkIds);
+          describe('on device change', () => {
+            it('should publish a device-change event', () => {
+              device.audio && device.audio.emit('deviceChange', [{ deviceId: 'foo' }]);
+              sinon.assert.calledOnce(publisher.info);
+              sinon.assert.calledWith(publisher.info, 'audio', 'device-change', {
+                lost_active_device_ids: ['foo'],
               });
-          });
-
-          it('should call _setSinkIds on the active connection', () => {
-            device.connect();
-            const sinkIds = ['default'];
-            activeConnection._setSinkIds = sinon.spy(() => Promise.resolve())
-            updateSinkIds('speaker', sinkIds);
-            sinon.assert.calledOnce(activeConnection._setSinkIds);
-            sinon.assert.calledWith(activeConnection._setSinkIds, sinkIds);
-          });
-
-          context('if successful', () => {
-            let sinkIds: string[];
-            beforeEach(() => {
-              device.connect();
-              sinkIds = ['default'];
-              activeConnection._setSinkIds = sinon.spy(() => Promise.resolve())
-              return updateSinkIds('speaker', sinkIds);
-            });
-
-            it('should publish a speaker-devices-set event', () => {
-              sinon.assert.calledOnce(publisher.info);
-              sinon.assert.calledWith(publisher.info, 'audio', 'speaker-devices-set',
-                { audio_device_ids: sinkIds });
             });
           });
 
-          context('if unsuccessful', () => {
-            let sinkIds: string[];
-            beforeEach(() => {
-              device.connect();
-              sinkIds = ['default'];
-              activeConnection._setSinkIds = sinon.spy(() => Promise.reject(new Error('foo')));
-              return updateSinkIds('speaker', sinkIds).then(
-                () => { throw Error('Expected a rejection') },
-                () => Promise.resolve());
-            });
-
-            it('should publish a speaker-devices-set event', () => {
-              sinon.assert.calledOnce(publisher.error);
-              sinon.assert.calledWith(publisher.error, 'audio', 'speaker-devices-set-failed',
-                { audio_device_ids: sinkIds, message: 'foo' });
+          describe('createDefaultPayload', () => {
+            xit('should be tested', () => {
+              // This should be moved somewhere that it can be tested. This is currently:
+              // A) Internal to Device where it can't easily be tested and
+              // B) Reaching into Connection, causing a weird coupling.
             });
           });
-        });
 
-        context(`when type is 'ringtone'`, () => {
-          it('should call setSinkIds on incoming', () => {
-            const sinkIds = ['default'];
-            updateSinkIds('ringtone', sinkIds);
-            sinon.assert.calledOnce(sounds[Device.SoundName.Incoming].setSinkIds);
-            sinon.assert.calledWith(sounds[Device.SoundName.Incoming].setSinkIds, sinkIds);
-          });
-
-          context('if successful', () => {
-            let sinkIds: string[];
-            beforeEach(() => {
-              device.connect();
-              sinkIds = ['default'];
-              activeConnection._setSinkIds = sinon.spy(() => Promise.resolve())
-              return updateSinkIds('ringtone', sinkIds);
+          describe('on unload or pagehide', () => {
+            it('should call destroy once on pagehide', () => {
+              stub = sinon.createStubInstance(Device);
+              Device.prototype.constructor.call(stub, token);
+              root.window.dispatchEvent('pagehide');
+              sinon.assert.calledOnce(stub.destroy);
             });
 
-            it('should publish a ringtone-devices-set event', () => {
-              sinon.assert.calledOnce(publisher.info);
-              sinon.assert.calledWith(publisher.info, 'audio', 'ringtone-devices-set',
-                { audio_device_ids: sinkIds });
+            it('should call destroy once on unload', () => {
+              stub = sinon.createStubInstance(Device);
+              Device.prototype.constructor.call(stub, token);
+              root.window.dispatchEvent('unload');
+              sinon.assert.calledOnce(stub.destroy);
             });
           });
         });
@@ -1015,12 +1248,12 @@ function createEmitterStub(BaseClass: any): SinonStubbedInstance<any> {
 function createToken(identity: string): string {
   const token = new ClientCapability({
     accountSid: 'AC1234567890123456789012',
-    authToken: 'authToken'
+    authToken: 'authToken',
   });
 
   token.addScope(new ClientCapability.OutgoingClientScope({
     applicationSid: 'AP123',
-    clientName: identity
+    clientName: identity,
   }));
 
   token.addScope(new ClientCapability.IncomingClientScope(identity));

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -8,7 +8,7 @@ import * as sinon from 'sinon';
 import { inherits } from 'util';
 import RTCSample from '../../lib/twilio/rtc/sample';
 
-describe.only('PreflightTest', () => {
+describe('PreflightTest', () => {
   const CALL_SID = 'foo-bar';
 
   let clock: SinonFakeTimers;
@@ -303,7 +303,7 @@ describe.only('PreflightTest', () => {
       await clock.tickAsync(5000);
       device.emit('disconnect');
       await clock.tickAsync(1000);
-      device.emit('offline');
+      device.emit(Device.EventName.Unregistered);
 
       await clock.tickAsync(20000);
       sinon.assert.notCalled(deviceContext.disconnectAll);
@@ -315,7 +315,7 @@ describe.only('PreflightTest', () => {
       device.emit(Device.EventName.Registered);
       await clock.tickAsync(5000);
       preflight.stop();
-      device.emit('offline');
+      device.emit(Device.EventName.Unregistered);
       await clock.tickAsync(20000);
       sinon.assert.notCalled(deviceContext.disconnectAll);
     });
@@ -462,7 +462,7 @@ describe.only('PreflightTest', () => {
       await clock.tickAsync(5000);
       device.emit('disconnect');
       await clock.tickAsync(1000);
-      device.emit('offline');
+      device.emit(Device.EventName.Unregistered);
 
       await clock.tickAsync(15000);
       sinon.assert.notCalled(onFailed);
@@ -475,7 +475,7 @@ describe.only('PreflightTest', () => {
       await clock.tickAsync(14000);
       device.emit('disconnect');
       await clock.tickAsync(1000);
-      device.emit('offline');
+      device.emit(Device.EventName.Unregistered);
       await clock.tickAsync(10);
 
       // endTime - startTime = duration. Should be equal to the total clock ticks
@@ -491,7 +491,7 @@ describe.only('PreflightTest', () => {
       await clock.tickAsync(14000);
       device.emit('disconnect');
       await clock.tickAsync(1000);
-      device.emit('offline');
+      device.emit(Device.EventName.Unregistered);
       await clock.tickAsync(1000);
       assert.equal(device.eventNames().length, 0);
       assert.equal(connection.eventNames().length, 0);
@@ -609,7 +609,7 @@ describe.only('PreflightTest', () => {
         device.emit('disconnect');
 
         await clock.tickAsync(1000);
-        device.emit('offline');
+        device.emit(Device.EventName.Unregistered);
         await clock.tickAsync(1000);
       });
     });
@@ -628,7 +628,7 @@ describe.only('PreflightTest', () => {
         await clock.tickAsync(13000);
         device.emit('disconnect');
         await clock.tickAsync(1000);
-        device.emit('offline');
+        device.emit(Device.EventName.Unregistered);
         await clock.tickAsync(1000);
 
         await completePromise;
@@ -674,7 +674,7 @@ describe.only('PreflightTest', () => {
           await clock.tickAsync(13000);
           device.emit('disconnect');
           await clock.tickAsync(5000);
-          device.emit('offline');
+          device.emit(Device.EventName.Unregistered);
           await clock.tickAsync(5000);
 
           await completePromise;
@@ -691,7 +691,7 @@ describe.only('PreflightTest', () => {
         await clock.tickAsync(25000);
         device.emit('disconnect');
         await clock.tickAsync(1000);
-        device.emit('offline');
+        device.emit(Device.EventName.Unregistered);
         await clock.tickAsync(1000);
       };
 
@@ -803,7 +803,7 @@ describe.only('PreflightTest', () => {
       await clock.tickAsync(5000);
 
       preflight.stop();
-      device.emit('offline');
+      device.emit(Device.EventName.Unregistered);
 
       await clock.tickAsync(15000);
 
@@ -856,7 +856,7 @@ describe.only('PreflightTest', () => {
       await clock.tickAsync(0);
 
       preflight.stop();
-      device.emit('offline');
+      device.emit(Device.EventName.Unregistered);
       await clock.tickAsync(1000);
 
       assert.equal(preflight.status, PreflightTest.Status.Failed);
@@ -919,10 +919,10 @@ describe.only('PreflightTest', () => {
 
       await clock.tickAsync(5000);
       preflight.stop();
-      device.emit('offline');
+      device.emit(Device.EventName.Unregistered);
 
       await clock.tickAsync(15000);
-      device.emit('offline');
+      device.emit(Device.EventName.Unregistered);
       await clock.tickAsync(1000);
       assert.equal(preflight.status, PreflightTest.Status.Failed);
       sinon.assert.notCalled(onCompleted);
@@ -934,7 +934,7 @@ describe.only('PreflightTest', () => {
       await clock.tickAsync(0);
 
       preflight.stop();
-      device.emit('offline');
+      device.emit(Device.EventName.Unregistered);
       await clock.tickAsync(1000);
 
       assert.equal(device.eventNames().length, 0);
@@ -953,7 +953,7 @@ describe.only('PreflightTest', () => {
       await clock.tickAsync(1000);
       device.emit('disconnect');
       await clock.tickAsync(1000);
-      device.emit('offline');
+      device.emit(Device.EventName.Unregistered);
       await clock.tickAsync(1);
       device.emit('error', { code: 123 });
       await clock.tickAsync(1000);

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -301,7 +301,7 @@ describe('PreflightTest', () => {
       await clock.tickAsync(1000);
 
       await clock.tickAsync(5000);
-      device.emit('disconnect');
+      connection.emit('disconnect');
       await clock.tickAsync(1000);
       device.emit(Device.EventName.Unregistered);
 
@@ -460,7 +460,7 @@ describe('PreflightTest', () => {
 
       device.emit(Device.EventName.Registered);
       await clock.tickAsync(5000);
-      device.emit('disconnect');
+      connection.emit('disconnect');
       await clock.tickAsync(1000);
       device.emit(Device.EventName.Unregistered);
 
@@ -473,7 +473,7 @@ describe('PreflightTest', () => {
       preflight.on('completed', onCompleted);
       device.emit(Device.EventName.Registered);
       await clock.tickAsync(14000);
-      device.emit('disconnect');
+      connection.emit('disconnect');
       await clock.tickAsync(1000);
       device.emit(Device.EventName.Unregistered);
       await clock.tickAsync(10);
@@ -489,7 +489,7 @@ describe('PreflightTest', () => {
       preflight.on('completed', onCompleted);
       device.emit(Device.EventName.Registered);
       await clock.tickAsync(14000);
-      device.emit('disconnect');
+      connection.emit('disconnect');
       await clock.tickAsync(1000);
       device.emit(Device.EventName.Unregistered);
       await clock.tickAsync(1000);
@@ -606,7 +606,7 @@ describe('PreflightTest', () => {
         connection['_mediaHandler'].onsignalingstatechange('stable');
 
         await clock.tickAsync(13000);
-        device.emit('disconnect');
+        connection.emit('disconnect');
 
         await clock.tickAsync(1000);
         device.emit(Device.EventName.Unregistered);
@@ -626,7 +626,7 @@ describe('PreflightTest', () => {
         device.emit(Device.EventName.Registered);
 
         await clock.tickAsync(13000);
-        device.emit('disconnect');
+        connection.emit('disconnect');
         await clock.tickAsync(1000);
         device.emit(Device.EventName.Unregistered);
         await clock.tickAsync(1000);
@@ -672,7 +672,7 @@ describe('PreflightTest', () => {
           }
 
           await clock.tickAsync(13000);
-          device.emit('disconnect');
+          connection.emit('disconnect');
           await clock.tickAsync(5000);
           device.emit(Device.EventName.Unregistered);
           await clock.tickAsync(5000);
@@ -689,7 +689,7 @@ describe('PreflightTest', () => {
 
         connection.emit('sample', testSamples[0]);
         await clock.tickAsync(25000);
-        device.emit('disconnect');
+        connection.emit('disconnect');
         await clock.tickAsync(1000);
         device.emit(Device.EventName.Unregistered);
         await clock.tickAsync(1000);
@@ -951,7 +951,7 @@ describe('PreflightTest', () => {
 
       device.emit(Device.EventName.Registered);
       await clock.tickAsync(1000);
-      device.emit('disconnect');
+      connection.emit('disconnect');
       await clock.tickAsync(1000);
       device.emit(Device.EventName.Unregistered);
       await clock.tickAsync(1);

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -1,4 +1,5 @@
 import Connection from '../../lib/twilio/connection';
+import Device from '../../lib/twilio/device';
 import { PreflightTest } from '../../lib/twilio/preflight/preflight';
 import { EventEmitter } from 'events';
 import { SinonFakeTimers } from 'sinon';
@@ -7,7 +8,7 @@ import * as sinon from 'sinon';
 import { inherits } from 'util';
 import RTCSample from '../../lib/twilio/rtc/sample';
 
-describe('PreflightTest', () => {
+describe.only('PreflightTest', () => {
   const CALL_SID = 'foo-bar';
 
   let clock: SinonFakeTimers;
@@ -25,9 +26,14 @@ describe('PreflightTest', () => {
   let wait: any;
 
   const getDeviceFactory = (context: any) => {
-    const factory = function(this: any, options: PreflightTest.Options) {
+    const factory = function(
+      this: any,
+      token: string,
+      options: PreflightTest.Options,
+    ) {
       Object.assign(this, context);
-      this.setOptions(options);
+      this.updateToken(token);
+      this.updateOptions(options);
       device = this;
     };
     inherits(factory, EventEmitter);
@@ -95,13 +101,14 @@ describe('PreflightTest', () => {
         disconnect: sinon.stub(),
         outgoing: sinon.stub(),
       },
-      connect: sinon.stub().returns(connection),
+      connect: sinon.stub().returns(Promise.resolve(connection)),
       destroy: sinon.stub(),
       disconnectAll: sinon.stub(),
       edge: null,
       region: sinon.stub().returns('foobar-region'),
-      register: sinon.stub(),
-      setOptions: sinon.stub(),
+      register: sinon.stub().returns(Promise.resolve()),
+      updateOptions: sinon.stub(),
+      updateToken: sinon.stub(),
     };
     edgeStub = sinon.stub().returns('foobar-edge');
     sinon.stub(deviceContext, 'edge').get(edgeStub);
@@ -129,77 +136,61 @@ describe('PreflightTest', () => {
   describe('constructor', () => {
     it('should pass defaults to device', () => {
       const preflight = new PreflightTest('foo', options);
-      sinon.assert.calledWith(deviceContext.setOptions, {
+      sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
         codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
+        edge: 'roaming',
         fileInputStream: undefined,
         logLevel: 'error',
         preflight: true,
-      });
-      sinon.assert.calledWith(deviceContext.register, 'foo', {
-        edge: 'roaming',
       });
     });
 
     it('should pass codecPreferences to device', () => {
       options.codecPreferences = [Connection.Codec.PCMU];
       const preflight = new PreflightTest('foo', options);
-      sinon.assert.calledWith(deviceContext.setOptions, {
+      sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
         codecPreferences: options.codecPreferences,
+        edge: 'roaming',
         fileInputStream: undefined,
         logLevel: 'error',
         preflight: true,
-      });
-      sinon.assert.calledWith(deviceContext.register, 'foo', {
-        edge: 'roaming',
       });
     });
 
     it('should pass logLevel to device', () => {
       options.logLevel = 'debug';
       const preflight = new PreflightTest('foo', options);
-      sinon.assert.calledWith(deviceContext.setOptions, {
+      sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
         codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
-        fileInputStream: undefined,
-        logLevel: 'debug',
-        preflight: true,
-      });
-      sinon.assert.calledWith(deviceContext.register, 'foo', {
         edge: 'roaming',
+        fileInputStream: undefined,
+        logLevel: options.logLevel,
+        preflight: true,
       });
     });
 
     it('should pass edge to device', () => {
       options.edge = 'ashburn';
       const preflight = new PreflightTest('foo', options);
-      sinon.assert.calledWith(deviceContext.setOptions, {
+      sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
         codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
+        edge: options.edge,
         fileInputStream: undefined,
         logLevel: 'error',
         preflight: true,
       });
       sinon.assert.calledOnce(edgeStub);
-      sinon.assert.calledWith(deviceContext.register, 'foo', {
-        edge: options.edge,
-      });
     });
 
-    it('should pass rtcConfiguration to device.connect', () => {
+    it('should pass rtcConfiguration to device', () => {
       options.rtcConfiguration = {foo: 'foo', iceServers: 'bar'};
       const preflight = new PreflightTest('foo', options);
-      device.emit('ready');
-      return wait().then(() => {
-        sinon.assert.calledWith(deviceContext.setOptions, {
-          codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
-          fileInputStream: undefined,
-          logLevel: 'error',
-          preflight: true,
-        });
-        sinon.assert.calledWith(deviceContext.register, 'foo', {
-          edge: 'roaming',
-        });
-        sinon.assert.calledWith(deviceContext.connect, {
-          rtcConfiguration: options.rtcConfiguration,
-        });
+      sinon.assert.calledWith(deviceContext.updateOptions, {
+        codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
+        edge: 'roaming',
+        fileInputStream: undefined,
+        logLevel: 'error',
+        preflight: true,
       });
     });
   });
@@ -239,30 +230,27 @@ describe('PreflightTest', () => {
 
     it('should set fakeMicInput to false by default', () => {
       preflight = new PreflightTest('foo', options);
-      sinon.assert.calledWith(deviceContext.setOptions, {
+      sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
         codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
+        edge: 'roaming',
         fileInputStream: undefined,
         logLevel: 'error',
         preflight: true,
       });
-      sinon.assert.calledWith(deviceContext.register, 'foo', {
-        edge: 'roaming',
-      });
+      sinon.assert.calledOnceWithExactly(deviceContext.register);
     });
 
-    it('should pass file input if fakeMicInput is true', () => {
+    it('should pass file input if fakeMicInput is true', async () => {
       preflight = new PreflightTest('foo', {...options, fakeMicInput: true });
-      return wait().then(() => {
-        sinon.assert.calledWith(deviceContext.setOptions, {
-          codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
-          fileInputStream: stream,
-          logLevel: 'error',
-          preflight: true,
-        });
-        sinon.assert.calledWith(deviceContext.register, 'foo', {
-          edge: 'roaming',
-        });
+      await clock.tickAsync(1000);
+      sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
+        codecPreferences: [Connection.Codec.PCMU, Connection.Codec.Opus],
+        edge: 'roaming',
+        fileInputStream: stream,
+        logLevel: 'error',
+        preflight: true,
       });
+      sinon.assert.calledOnceWithExactly(deviceContext.register);
     });
 
     it('should call play', () => {
@@ -276,89 +264,82 @@ describe('PreflightTest', () => {
       sinon.assert.calledWithExactly(audioInstance.setAttribute, 'crossorigin', 'anonymous');
     });
 
-    it('should mute device sounds', () => {
+    it('should mute device sounds', async () => {
       preflight = new PreflightTest('foo', {...options, fakeMicInput: true });
-      return wait().then(() => {
-        device.emit('ready');
-        sinon.assert.calledOnce(deviceContext.audio.disconnect);
-        sinon.assert.calledOnce(deviceContext.audio.outgoing);
-        sinon.assert.calledWithExactly(deviceContext.audio.disconnect, false);
-        sinon.assert.calledWithExactly(deviceContext.audio.outgoing, false);
-      });
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(1000);
+      sinon.assert.calledOnce(deviceContext.audio.disconnect);
+      sinon.assert.calledOnce(deviceContext.audio.outgoing);
+      sinon.assert.calledWithExactly(deviceContext.audio.disconnect, false);
+      sinon.assert.calledWithExactly(deviceContext.audio.outgoing, false);
     });
 
-    it('should end test after echo duration', () => {
+    it('should end test after echo duration', async () => {
       preflight = new PreflightTest('foo', {...options, fakeMicInput: true });
-      return wait().then(() => {
-        device.emit('ready');
-
-        clock.tick(19000);
-        sinon.assert.notCalled(deviceContext.disconnectAll);
-        clock.tick(1000);
-        sinon.assert.calledOnce(deviceContext.disconnectAll);
-      });
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(19000);
+      sinon.assert.notCalled(deviceContext.disconnectAll);
+      await clock.tickAsync(1000);
+      sinon.assert.calledOnce(deviceContext.disconnectAll);
     });
 
-    it('should not start timer if fakeMicInput is false', () => {
+    it('should not start timer if fakeMicInput is false', async () => {
       preflight = new PreflightTest('foo', options);
-      return wait().then(() => {
-        device.emit('ready');
-
-        clock.tick(19000);
-        sinon.assert.notCalled(deviceContext.disconnectAll);
-        clock.tick(20000);
-        sinon.assert.notCalled(deviceContext.disconnectAll);
-      });
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(19000);
+      sinon.assert.notCalled(deviceContext.disconnectAll);
+      await clock.tickAsync(20000);
+      sinon.assert.notCalled(deviceContext.disconnectAll);
     });
 
-    it('should clear echo timer on completed', () => {
+    it('should clear echo timer on completed', async () => {
       preflight = new PreflightTest('foo', {...options, fakeMicInput: true });
-      device.emit('ready');
+
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(1000);
       connection.emit('sample', testSamples[0]);
-      return wait().then(() => {
-        clock.tick(5000);
-        device.emit('disconnect');
-        clock.tick(1000);
-        device.emit('offline');
+      await clock.tickAsync(1000);
 
-        clock.tick(20000);
-        sinon.assert.notCalled(deviceContext.disconnectAll);
-      });
+      await clock.tickAsync(5000);
+      device.emit('disconnect');
+      await clock.tickAsync(1000);
+      device.emit('offline');
+
+      await clock.tickAsync(20000);
+      sinon.assert.notCalled(deviceContext.disconnectAll);
     });
 
-    it('should clear echo timer on failed', () => {
+    it('should clear echo timer on failed', async () => {
       preflight = new PreflightTest('foo', {...options, fakeMicInput: true });
 
-      return wait().then(() => {
-        device.emit('ready');
-        clock.tick(5000);
-        preflight.stop();
-        device.emit('offline');
-        clock.tick(20000);
-        sinon.assert.notCalled(deviceContext.disconnectAll);
-      });
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(5000);
+      preflight.stop();
+      device.emit('offline');
+      await clock.tickAsync(20000);
+      sinon.assert.notCalled(deviceContext.disconnectAll);
     });
 
-    it('should not mute media stream if fakeMicInput is false', () => {
+    it('should not mute media stream if fakeMicInput is false', async () => {
       preflight = new PreflightTest('foo', options);
 
-      return wait().then(() => {
-        device.emit('ready');
-        connection.emit('volume');
-        assert(!connectionContext['_mediaHandler'].outputs.get('default').audio.muted);
-        assert(!connectionContext['_mediaHandler'].outputs.get('foo').audio.muted);
-      });
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(1000);
+      connection.emit('volume');
+      await clock.tickAsync(1000);
+      assert(!connectionContext['_mediaHandler'].outputs.get('default').audio.muted);
+      assert(!connectionContext['_mediaHandler'].outputs.get('foo').audio.muted);
     });
 
-    it('should mute media stream if fakeMicInput is true', () => {
+    it('should mute media stream if fakeMicInput is true', async () => {
       preflight = new PreflightTest('foo', {...options, fakeMicInput: true });
 
-      return wait().then(() => {
-        device.emit('ready');
-        connection.emit('volume');
-        assert(connectionContext['_mediaHandler'].outputs.get('default').audio.muted);
-        assert(connectionContext['_mediaHandler'].outputs.get('foo').audio.muted);
-      });
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(1000);
+      connection.emit('volume');
+      await clock.tickAsync(1000);
+      assert(connectionContext['_mediaHandler'].outputs.get('default').audio.muted);
+      assert(connectionContext['_mediaHandler'].outputs.get('foo').audio.muted);
     });
   });
 
@@ -367,14 +348,15 @@ describe('PreflightTest', () => {
       const onSample = sinon.stub();
       const preflight = new PreflightTest('foo', options);
       preflight.on('sample', onSample);
-      device.emit('ready');
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(1000);
 
       const count = 10;
       const sample = {foo: 'foo', bar: 'bar', mos: 1};
       for (let i = 1; i <= count; i++) {
         const data = {...sample, count: i};
         connection.emit('sample', data);
-        await wait();
+        await clock.tickAsync(1000);
         sinon.assert.callCount(onSample, i);
         sinon.assert.calledWithExactly(onSample, data);
         assert.deepEqual(preflight.latestSample, data)
@@ -388,14 +370,16 @@ describe('PreflightTest', () => {
       preflight = new PreflightTest('foo', options);
     });
 
-    it('should emit warning', () => {
+    it('should emit warning', async () => {
       const onWarning = sinon.stub();
       preflight.on('warning', onWarning);
-      device.emit('ready');
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(1000);
 
       const data = {foo: 'foo', bar: 'bar'};
 
       connection.emit('warning', 'foo', data);
+      await clock.tickAsync(1000);
 
       sinon.assert.calledOnce(onWarning);
       sinon.assert.calledWithExactly(onWarning, {
@@ -405,51 +389,58 @@ describe('PreflightTest', () => {
       });
     });
 
-    it('should emit a warning the first time Insights fails to publish', () => {
+    it('should emit a warning the first time Insights fails to publish', async () => {
       const onWarning = sinon.stub();
       preflight.on('warning', onWarning);
-      device.emit('ready');
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(1000);
 
       publisher.emit('error');
+      await clock.tickAsync(1000);
       sinon.assert.calledOnce(onWarning);
       sinon.assert.calledWithExactly(onWarning, {
         description: 'Received an error when attempting to connect to Insights gateway',
         name: 'insights-connection-error',
       });
+
       publisher.emit('error');
+      await clock.tickAsync(1000);
       sinon.assert.calledOnce(onWarning);
     });
   });
 
   describe('on connected', () => {
-    it('should emit connected', () => {
+    it('should emit connected', async () => {
       const onConnected = sinon.stub();
       const preflight = new PreflightTest('foo', options);
 
       preflight.on('connected', onConnected);
-      device.emit('ready');
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(1000);
 
       connection.emit('accept');
+      await clock.tickAsync(1000);
       assert.equal(preflight.status, PreflightTest.Status.Connected);
       sinon.assert.calledOnce(onConnected);
     });
 
-    it('should populate callsid', () => {
+    it('should populate callsid', async () => {
       const preflight = new PreflightTest('foo', options);
-      device.emit('ready');
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(1000);
       connection.emit('accept');
+      await clock.tickAsync(1000);
 
       assert.equal(preflight.callSid, CALL_SID);
     });
 
-    it('should clear singaling timeout timer', () => {
+    it('should clear singaling timeout timer', async () => {
       const onFailed = sinon.stub();
       const preflight = new PreflightTest('foo', options);
 
       preflight.on('failed', onFailed);
-      device.emit('ready');
-
-      clock.tick(15000);
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(15000);
 
       sinon.assert.notCalled(onFailed);
     });
@@ -463,29 +454,29 @@ describe('PreflightTest', () => {
       preflight['_rtcIceCandidateStatsReport'] = rtcIceCandidateStatsReport;
     });
 
-    it('should clear signaling timeout timer', () => {
+    it('should clear signaling timeout timer', async () => {
       const onFailed = sinon.stub();
       preflight.on('failed', onFailed);
 
-      device.emit('ready');
-      clock.tick(5000);
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(5000);
       device.emit('disconnect');
-      clock.tick(1000);
+      await clock.tickAsync(1000);
       device.emit('offline');
 
-      clock.tick(15000);
+      await clock.tickAsync(15000);
       sinon.assert.notCalled(onFailed);
     });
 
-    it('should end call after device disconnects', () => {
+    it('should end call after device disconnects', async () => {
       const onCompleted = sinon.stub();
       preflight.on('completed', onCompleted);
-      device.emit('ready');
-      clock.tick(14000);
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(14000);
       device.emit('disconnect');
-      clock.tick(1000);
+      await clock.tickAsync(1000);
       device.emit('offline');
-      clock.tick(10);
+      await clock.tickAsync(10);
 
       // endTime - startTime = duration. Should be equal to the total clock ticks
       assert(preflight.endTime! - preflight.startTime === 15010);
@@ -493,15 +484,15 @@ describe('PreflightTest', () => {
       sinon.assert.called(onCompleted);
     });
 
-    it('should release all handlers', () => {
+    it('should release all handlers', async () => {
       const onCompleted = sinon.stub();
       preflight.on('completed', onCompleted);
-      device.emit('ready');
-      clock.tick(14000);
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(14000);
       device.emit('disconnect');
-      clock.tick(1000);
+      await clock.tickAsync(1000);
       device.emit('offline');
-      clock.tick(1000);
+      await clock.tickAsync(1000);
       assert.equal(device.eventNames().length, 0);
       assert.equal(connection.eventNames().length, 0);
     });
@@ -588,14 +579,15 @@ describe('PreflightTest', () => {
         };
 
         preflight.on('completed', onCompleted);
-        device.emit('ready');
+        device.emit(Device.EventName.Registered);
+        await clock.tickAsync(0);
 
         // Populate samples
         for (let i = 0; i < testSamples.length; i++) {
           const sample = testSamples[i];
           const data = {...sample};
           connection.emit('sample', data);
-          await wait();
+          await clock.tickAsync(1);
         }
         // Populate warnings
         connection.emit('warning', 'foo', warningData);
@@ -606,37 +598,40 @@ describe('PreflightTest', () => {
         connection['_mediaHandler'].onpcconnectionstatechange('connecting');
         connection['_mediaHandler'].ondtlstransportstatechange('connecting');
         connection['_mediaHandler'].oniceconnectionstatechange('checking');
-        clock.tick(1000);
+        await clock.tickAsync(1000);
 
         connection['_mediaHandler'].onpcconnectionstatechange('connected');
         connection['_mediaHandler'].ondtlstransportstatechange('connected');
         connection['_mediaHandler'].oniceconnectionstatechange('connected');
         connection['_mediaHandler'].onsignalingstatechange('stable');
 
-        clock.tick(13000);
+        await clock.tickAsync(13000);
         device.emit('disconnect');
 
-        clock.tick(1000);
+        await clock.tickAsync(1000);
         device.emit('offline');
-        clock.tick(1000);
+        await clock.tickAsync(1000);
       });
     });
 
     describe('call quality', () => {
-      it('should not include callQuality if stats are missing', (done) => {
-        const onCompleted = (results: PreflightTest.Report) => {
-          assert(!results.callQuality);
-          done();
-        };
+      it('should not include callQuality if stats are missing', async () => {
+        const completePromise = new Promise(resolve => {
+          preflight.on('completed', (results: PreflightTest.Report) => {
+            assert(!results.callQuality);
+            resolve();
+          });
+        });
 
-        preflight.on('completed', onCompleted);
-        device.emit('ready');
+        device.emit(Device.EventName.Registered);
 
-        clock.tick(13000);
+        await clock.tickAsync(13000);
         device.emit('disconnect');
-        clock.tick(1000);
+        await clock.tickAsync(1000);
         device.emit('offline');
-        clock.tick(1000);
+        await clock.tickAsync(1000);
+
+        await completePromise;
       });
 
       // Test data for different mos and expected quality
@@ -656,45 +651,48 @@ describe('PreflightTest', () => {
         [3.000, PreflightTest.CallQuality.Degraded],
         [2.900, PreflightTest.CallQuality.Degraded],
       ].forEach(([averageMos, callQuality]) => {
-        it(`should report quality as ${callQuality} if average mos is ${averageMos}`, () => {
-          return new Promise(async (resolve) => {
-            const onCompleted = (results: PreflightTest.Report) => {
+        it(`should report quality as ${callQuality} if average mos is ${averageMos}`, async () => {
+          const completePromise = new Promise(resolve => {
+            preflight.on('completed', (results: PreflightTest.Report) => {
               assert.equal(results.callQuality, callQuality);
               resolve();
-            };
-
-            preflight.on('completed', onCompleted);
-            device.emit('ready');
-
-            for (let i = 0; i < 10; i++) {
-              connection.emit('sample', {
-                rtt: 1,
-                jitter: 1,
-                mos: averageMos,
-              });
-              await wait();
-            }
-
-            clock.tick(13000);
-            device.emit('disconnect');
-            clock.tick(1000);
-            device.emit('offline');
-            clock.tick(1000);
+            });
           });
+
+          device.emit(Device.EventName.Registered);
+          await clock.tickAsync(0);
+
+          for (let i = 0; i < 10; i++) {
+            connection.emit('sample', {
+              rtt: 1,
+              jitter: 1,
+              mos: averageMos,
+            });
+            await clock.tickAsync(1);
+          }
+
+          await clock.tickAsync(13000);
+          device.emit('disconnect');
+          await clock.tickAsync(5000);
+          device.emit('offline');
+          await clock.tickAsync(5000);
+
+          await completePromise;
         });
       })
     });
 
     describe('ice candidates', () => {
       const passPreflight = async () => {
-        device.emit('ready');
+        device.emit(Device.EventName.Registered);
+        await clock.tickAsync(0);
+
         connection.emit('sample', testSamples[0]);
-        await wait();
-        clock.tick(25000);
+        await clock.tickAsync(25000);
         device.emit('disconnect');
-        clock.tick(1000);
+        await clock.tickAsync(1000);
         device.emit('offline');
-        clock.tick(1000);
+        await clock.tickAsync(1000);
       };
 
       let candidateInfo: any;
@@ -796,69 +794,70 @@ describe('PreflightTest', () => {
   });
 
   describe('on failed', () => {
-    it('should clear signaling timeout timer', () => {
+    it('should clear signaling timeout timer', async () => {
       const onFailed = sinon.stub();
       const preflight = new PreflightTest('foo', options);
 
       preflight.on('failed', onFailed);
-      device.emit('ready');
-      clock.tick(5000);
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(5000);
 
       preflight.stop();
       device.emit('offline');
 
-      clock.tick(15000);
+      await clock.tickAsync(15000);
 
       sinon.assert.calledOnce(onFailed);
     });
 
-    it('should timeout after 10s by default', () => {
+    it('should timeout after 10s by default', async () => {
       const onFailed = sinon.stub();
       const preflight = new PreflightTest('foo', options);
       preflight.on('failed', onFailed);
 
-      clock.tick(9999);
+      await clock.tickAsync(9999);
       sinon.assert.notCalled(onFailed);
-      clock.tick(1);
+      await clock.tickAsync(1);
       sinon.assert.calledOnce(onFailed);
       sinon.assert.calledWithExactly(onFailed, { code: 31901, message: "WebSocket - Connection Timeout" });
     });
 
-    it('should use timeout param', () => {
+    it('should use timeout param', async () => {
       const onFailed = sinon.stub();
       const preflight = new PreflightTest('foo', Object.assign({ signalingTimeoutMs: 3000 }, options));
       preflight.on('failed', onFailed);
 
-      clock.tick(2999);
+      await clock.tickAsync(2999);
       sinon.assert.notCalled(onFailed);
-      clock.tick(1);
+      await clock.tickAsync(1);
       sinon.assert.calledOnce(onFailed);
       sinon.assert.calledWithExactly(onFailed, { code: 31901, message: "WebSocket - Connection Timeout" });
     });
 
-    it('should emit failed if Device failed to initialized', () => {
-      deviceContext.setOptions = () => {
+    it('should emit failed if Device failed to initialized', async () => {
+      deviceContext.updateOptions = () => {
         throw 'foo';
       };
 
       const onFailed = sinon.stub();
       const preflight = new PreflightTest('foo', options);
       preflight.on('failed', onFailed);
-      clock.tick(1);
+      await clock.tickAsync(1);
       assert.equal(preflight.status, PreflightTest.Status.Failed);
       sinon.assert.calledOnce(onFailed);
       sinon.assert.calledWithExactly(onFailed, 'foo');
     });
 
-    it('should emit failed when test is stopped and destroy device', () => {
+    it('should emit failed when test is stopped and destroy device', async () => {
       const onFailed = sinon.stub();
       const preflight = new PreflightTest('foo', options);
       preflight.on('failed', onFailed);
-      device.emit('ready');
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(0);
 
       preflight.stop();
       device.emit('offline');
-      clock.tick(1000);
+      await clock.tickAsync(1000);
 
       assert.equal(preflight.status, PreflightTest.Status.Failed);
       sinon.assert.calledOnce(deviceContext.destroy);
@@ -869,13 +868,15 @@ describe('PreflightTest', () => {
       });
     });
 
-    it(`should emit failed on fatal device errors and destroy device`, () => {
+    it(`should emit failed on fatal device errors and destroy device`, async () => {
       const onFailed = sinon.stub();
       const preflight = new PreflightTest('foo', options);
       preflight.on('failed', onFailed);
-      device.emit('ready');
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(0);
 
       device.emit('error', { code: 123 });
+      await clock.tickAsync(0);
 
       assert.equal(preflight.status, PreflightTest.Status.Failed);
       sinon.assert.calledOnce(deviceContext.destroy);
@@ -883,7 +884,7 @@ describe('PreflightTest', () => {
       sinon.assert.calledWithExactly(onFailed, { code: 123 });
     });
 
-    it('should listen to device error once', () => {
+    it('should listen to device error once', async () => {
       const onFailed = sinon.stub();
       const preflight = new PreflightTest('foo', options);
       preflight.on('failed', onFailed);
@@ -895,9 +896,14 @@ describe('PreflightTest', () => {
       device.on('error', sinon.stub());
 
       // Triggers the test
-      device.emit('ready');
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(0);
+
       device.emit('error', { code: 123 });
+      await clock.tickAsync(0);
+
       device.emit('error', { code: 123 });
+      await clock.tickAsync(0);
 
       assert.equal(preflight.status, PreflightTest.Status.Failed);
       sinon.assert.calledOnce(deviceContext.destroy);
@@ -905,36 +911,37 @@ describe('PreflightTest', () => {
       sinon.assert.calledWithExactly(onFailed, { code: 123 });
     });
 
-    it('should stop test', () => {
+    it('should stop test', async () => {
       const onCompleted = sinon.stub();
       const preflight = new PreflightTest('foo', options);
       preflight.on('completed', onCompleted);
-      device.emit('ready');
+      device.emit(Device.EventName.Registered);
 
-      clock.tick(5000);
+      await clock.tickAsync(5000);
       preflight.stop();
       device.emit('offline');
 
-      clock.tick(15000);
+      await clock.tickAsync(15000);
       device.emit('offline');
-      clock.tick(1000);
+      await clock.tickAsync(1000);
       assert.equal(preflight.status, PreflightTest.Status.Failed);
       sinon.assert.notCalled(onCompleted);
     });
 
-    it('should release all handlers', () => {
+    it('should release all handlers', async () => {
       const preflight = new PreflightTest('foo', options);
-      device.emit('ready');
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(0);
 
       preflight.stop();
       device.emit('offline');
-      clock.tick(1000);
+      await clock.tickAsync(1000);
 
       assert.equal(device.eventNames().length, 0);
       assert.equal(connection.eventNames().length, 0);
     });
 
-    it('should not emit completed event', () => {
+    it('should not emit completed event', async () => {
       const onCompleted = sinon.stub();
       const onFailed = sinon.stub();
       const preflight = new PreflightTest('foo', options);
@@ -942,14 +949,14 @@ describe('PreflightTest', () => {
       preflight.on(PreflightTest.Events.Completed, onCompleted);
       preflight.on(PreflightTest.Events.Failed, onFailed);
 
-      device.emit('ready');
-      clock.tick(1000);
+      device.emit(Device.EventName.Registered);
+      await clock.tickAsync(1000);
       device.emit('disconnect');
-      clock.tick(1000);
+      await clock.tickAsync(1000);
       device.emit('offline');
-      clock.tick(1);
+      await clock.tickAsync(1);
       device.emit('error', { code: 123 });
-      clock.tick(1000);
+      await clock.tickAsync(1000);
 
       return wait().then(() => {
         sinon.assert.notCalled(onCompleted);
@@ -995,8 +1002,10 @@ describe('PreflightTest', () => {
       it('should return an object if there are mos samples', async () => {
         const preflight = new PreflightTest('foo', options);
 
-        device.emit('ready');
-        [{
+        device.emit(Device.EventName.Registered);
+        await clock.tickAsync(0);
+
+        for (const sample of [{
           jitter: 100, mos: null, rtt: 1,
         }, {
           jitter: 0, mos: null, rtt: 0,
@@ -1008,11 +1017,10 @@ describe('PreflightTest', () => {
           jitter: 2, mos: 4, rtt: 0.03,
         }, {
           jitter: 3, mos: 3, rtt: 0.02,
-        }].map(createSample).forEach(
-          (sample: RTCSample) => connection.emit('sample', sample),
-        );
-
-        await wait();
+        }].map(createSample)) {
+          connection.emit('sample', sample);
+          await clock.tickAsync(0);
+        }
 
         const rtcStats = preflight['_getRTCStats']();
         assert.deepEqual(rtcStats, {
@@ -1037,7 +1045,9 @@ describe('PreflightTest', () => {
       it('should return undefined if there are no mos samples', async () => {
         const preflight = new PreflightTest('foo', options);
 
-        device.emit('ready');
+        device.emit(Device.EventName.Registered);
+        await clock.tickAsync(0);
+
         [{
           jitter: 100, mos: null, rtt: 1,
         }, {
@@ -1048,7 +1058,7 @@ describe('PreflightTest', () => {
           (sample: RTCSample) => connection.emit('sample', sample),
         );
 
-        await wait();
+        await clock.tickAsync(0);
 
         const rtcStats = preflight['_getRTCStats']();
         assert.equal(rtcStats, undefined);


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-8337](https://issues.corp.twilio.com/browse/CLIENT-8337)
- [CLIENT-8338](https://issues.corp.twilio.com/browse/CLIENT-8338)

### Description

This PR includes work for both CLIENT-8337 and CLIENT-8338. This PR implements lazy signaling where a signaling connection is only made when necessary, i.e. when registering and making a call. It also changes the `Device` states.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
