### PR TITLE
Add ability to set input stream

### DIFF
--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -318,6 +318,15 @@ class AudioHelper extends EventEmitter {
   }
 
   /**
+   * Replace the current input steamd with a new MediaStream.
+   * @param stream - A media stream to use as input
+   * @param device - A device to use as input
+   */
+  setInputStream(stream: MediaStream, device: MediaDeviceInfo | null): Promise<void> {
+    return this._setInputStream(stream, device);
+  }
+
+  /**
    * Unset the MediaTrackConstraints to be applied on every getUserMedia call for new input
    * device audio. The returned Promise resolves when the media is successfully reacquired,
    * or immediately if no input device is set.
@@ -487,13 +496,22 @@ class AudioHelper extends EventEmitter {
 
     const constraints = { audio: Object.assign({ deviceId: { exact: deviceId } }, this.audioConstraints) };
     return this._getUserMedia(constraints).then((stream: MediaStream) => {
-      return this._onActiveInputChanged(stream).then(() => {
-        this._replaceStream(stream);
-        this._inputDevice = device;
-        this._maybeStartPollingVolume();
-      });
+      return this._setInputStream(stream, device);
     });
   }
+
+  /**
+   * Replace the current input steamd with a new MediaStream.
+   * @param stream - A media stream to use as input
+   * @param device - A device to use as input
+   */
+   private _setInputStream(stream: MediaStream, device: MediaDeviceInfo | null): Promise<void> {
+    return this._onActiveInputChanged(stream).then(() => {
+      this._replaceStream(stream);
+      this._inputDevice = device;
+      this._maybeStartPollingVolume();
+    });
+ }
 
   /**
    * Update the available input and output devices


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

Adds the ability to specify an input audio stream rather than limiting input selection to devices. If there is desire to accept this change I can continue to run through the steps below.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
