### PR TITLE
Fix Call and Preflight to only emit TwilioError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,13 @@ class TwilioError extends Error {
 }
 ```
 
+#### Affected Error Codes
+With the transition, the following error codes have changed:
+- 31003 -> 53405 | When ICE connection fails
+- 31201 -> 31402 | When getting user media fails
+- 31208 -> 31401 | When user denies access to user media
+- 31901 -> 53000 | When websocket times out in preflight
+
 New Features
 ------------
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -943,7 +943,7 @@ class Device extends EventEmitter {
       this._publisher.info('settings', 'edge', data, call);
     });
 
-    call.addListener('error', (error: Call.Error) => {
+    call.addListener('error', (error: TwilioError) => {
       if (call.status() === 'closed') {
         this._removeCall(call);
       }
@@ -1483,37 +1483,6 @@ namespace Device {
    * Names of all togglable sounds.
    */
   export type ToggleableSound = Device.SoundName.Incoming | Device.SoundName.Outgoing | Device.SoundName.Disconnect;
-
-  /**
-   * The error format used by errors emitted from {@link Device}.
-   */
-  export interface Error {
-    /**
-     * Reference to the {@link Call}
-     * This is usually available if the error is coming from {@link Call}
-     */
-    call?: Call;
-
-    /**
-     * Error code
-     */
-    code: number;
-
-    /**
-     * The info object from rtc/peerconnection or eventpublisher. May contain code and message (duplicated here).
-     */
-    info?: { code?: number, message?: string };
-
-    /**
-     * Error message
-     */
-    message: string;
-
-    /**
-     * Twilio Voice related error
-     */
-    twilioError?: TwilioError;
-  }
 
   /**
    * Options to be passed to {@link Device.connect}.

--- a/lib/twilio/errors/generated.ts
+++ b/lib/twilio/errors/generated.ts
@@ -119,6 +119,25 @@ export namespace GeneralErrors {
     }
   }
 
+  export class CallCancelledError extends TwilioError {
+    causes: string[] = [
+      'The incoming call was cancelled because it was not answered in time or it was accepted/rejected by another application instance registered with the same identity.',
+    ];
+    code: number = 31008;
+    description: string = 'Call cancelled';
+    explanation: string = 'Unable to answer because the call has ended';
+    solutions: string[] = [];
+
+    constructor();
+    constructor(message: string);
+    constructor(originalError: Error);
+    constructor(message: string, originalError?: Error);
+    constructor(messageOrError?: string | Error, originalError?: Error) {
+      super(messageOrError, originalError);
+      Object.setPrototypeOf(this, GeneralErrors.CallCancelledError.prototype);
+    }
+  }
+
   export class TransportError extends TwilioError {
     causes: string[] = [];
     code: number = 31009;
@@ -133,6 +152,54 @@ export namespace GeneralErrors {
     constructor(messageOrError?: string | Error, originalError?: Error) {
       super(messageOrError, originalError);
       Object.setPrototypeOf(this, GeneralErrors.TransportError.prototype);
+    }
+  }
+}
+
+export namespace UserMediaErrors {
+  export class PermissionDeniedError extends TwilioError {
+    causes: string[] = [
+      'The user denied the getUserMedia request.',
+      'The browser denied the getUserMedia request.',
+    ];
+    code: number = 31401;
+    description: string = 'UserMedia Permission Denied Error';
+    explanation: string = 'The browser or end-user denied permissions to user media. Therefore we were unable to acquire input audio.';
+    solutions: string[] = [
+      'The user should accept the request next time prompted. If the browser saved the deny, the user should change that permission in their browser.',
+      'The user should to verify that the browser has permission to access the microphone at this address.',
+    ];
+
+    constructor();
+    constructor(message: string);
+    constructor(originalError: Error);
+    constructor(message: string, originalError?: Error);
+    constructor(messageOrError?: string | Error, originalError?: Error) {
+      super(messageOrError, originalError);
+      Object.setPrototypeOf(this, UserMediaErrors.PermissionDeniedError.prototype);
+    }
+  }
+
+  export class AcquisitionFailedError extends TwilioError {
+    causes: string[] = [
+      'NotFoundError - The deviceID specified was not found.',
+      'The getUserMedia constraints were overconstrained and no devices matched.',
+    ];
+    code: number = 31402;
+    description: string = 'UserMedia Acquisition Failed Error';
+    explanation: string = 'The browser and end-user allowed permissions, however getting the media failed. Usually this is due to bad constraints, but can sometimes fail due to browser, OS or hardware issues.';
+    solutions: string[] = [
+      'Ensure the deviceID being specified exists.',
+      'Try acquiring media with fewer constraints.',
+    ];
+
+    constructor();
+    constructor(message: string);
+    constructor(originalError: Error);
+    constructor(message: string, originalError?: Error);
+    constructor(messageOrError?: string | Error, originalError?: Error) {
+      super(messageOrError, originalError);
+      Object.setPrototypeOf(this, UserMediaErrors.AcquisitionFailedError.prototype);
     }
   }
 }
@@ -258,7 +325,10 @@ export const errorsByCode: ReadonlyMap<number, any> = new Map([
   [ 31400, ClientErrors.BadRequest ],
   [ 31000, GeneralErrors.UnknownError ],
   [ 31005, GeneralErrors.ConnectionError ],
+  [ 31008, GeneralErrors.CallCancelledError ],
   [ 31009, GeneralErrors.TransportError ],
+  [ 31401, UserMediaErrors.PermissionDeniedError ],
+  [ 31402, UserMediaErrors.AcquisitionFailedError ],
   [ 53000, SignalingErrors.ConnectionError ],
   [ 53001, SignalingErrors.ConnectionDisconnected ],
   [ 53400, MediaErrors.ClientLocalDescFailed ],

--- a/lib/twilio/errors/index.ts
+++ b/lib/twilio/errors/index.ts
@@ -11,6 +11,7 @@ import {
   MediaErrors,
   SignalingErrors,
   TwilioError,
+  UserMediaErrors,
 } from './generated';
 
 // Application errors that can be avoided by good app logic
@@ -57,4 +58,5 @@ export {
   MediaErrors,
   SignalingErrors,
   TwilioError,
+  UserMediaErrors,
 };

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "@twilio/audioplayer": "1.0.6",
-    "@twilio/voice-errors": "1.0.1",
+    "@twilio/voice-errors": "1.1.1",
     "backoff": "2.5.0",
     "loglevel": "1.6.7",
     "rtcpeerconnection-shim": "1.2.8",

--- a/templates/constants.js
+++ b/templates/constants.js
@@ -16,6 +16,7 @@ module.exports.USED_ERRORS = [
   'AuthorizationErrors.AccessTokenInvalid',
   'AuthorizationErrors.AuthenticationFailed',
   'ClientErrors.BadRequest',
+  'GeneralErrors.CallCancelledError',
   'GeneralErrors.ConnectionError',
   'GeneralErrors.TransportError',
   'GeneralErrors.UnknownError',
@@ -24,4 +25,6 @@ module.exports.USED_ERRORS = [
   'MediaErrors.ConnectionError',
   'SignalingErrors.ConnectionDisconnected',
   'SignalingErrors.ConnectionError',
+  'UserMediaErrors.PermissionDeniedError',
+  'UserMediaErrors.AcquisitionFailedError',
 ];

--- a/tests/integration/preflight.ts
+++ b/tests/integration/preflight.ts
@@ -4,6 +4,7 @@ import * as assert from 'assert';
 import { EventEmitter } from 'events';
 import { PreflightTest } from '../../lib/twilio/preflight/preflight';
 import Call from '../../lib/twilio/call';
+import { TwilioError } from '../../lib/twilio/errors';
 
 const DURATION_PADDING = 1000;
 const EVENT_TIMEOUT = 30000;
@@ -237,10 +238,7 @@ describe('Preflight Test', function() {
         preflight.stop();
       }, FAIL_DELAY);
       return waitFor(expectEvent('failed', preflight).then(error => {
-        assert.deepEqual(error, {
-          code: 31008,
-          message: 'Call cancelled',
-        });
+        assert.equal((error as TwilioError).code, 31008);
       }), EVENT_TIMEOUT);
     });
 

--- a/tests/unit/call.ts
+++ b/tests/unit/call.ts
@@ -1825,7 +1825,7 @@ describe('Call', function() {
         });
 
         const rVal = callback.firstCall.args[0];
-        assert.equal(rVal.twilioError.code, 53405);
+        assert.equal(rVal.code, 53405);
       });
 
       it('should publish warning on ICE Gathering timeout', () => {
@@ -1907,7 +1907,7 @@ describe('Call', function() {
       });
 
       const rVal = callback.firstCall.args[0];
-      assert.equal(rVal.twilioError.code, 53405);
+      assert.equal(rVal.code, 53405);
     });
 
     it('should emit reconnected on ice reconnected', () => {

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -1,5 +1,6 @@
 import Call from '../../lib/twilio/call';
 import Device from '../../lib/twilio/device';
+import { TwilioError } from '../../lib/twilio/errors';
 import { PreflightTest } from '../../lib/twilio/preflight/preflight';
 import { EventEmitter } from 'events';
 import { SinonFakeTimers } from 'sinon';
@@ -819,7 +820,7 @@ describe('PreflightTest', () => {
       sinon.assert.notCalled(onFailed);
       await clock.tickAsync(1);
       sinon.assert.calledOnce(onFailed);
-      sinon.assert.calledWithExactly(onFailed, { code: 31901, message: "WebSocket - Connection Timeout" });
+      assert.equal((onFailed.args[0][0] as TwilioError).code, 53000);
     });
 
     it('should use timeout param', async () => {
@@ -831,7 +832,7 @@ describe('PreflightTest', () => {
       sinon.assert.notCalled(onFailed);
       await clock.tickAsync(1);
       sinon.assert.calledOnce(onFailed);
-      sinon.assert.calledWithExactly(onFailed, { code: 31901, message: "WebSocket - Connection Timeout" });
+      assert.equal((onFailed.args[0][0] as TwilioError).code, 53000);
     });
 
     it('should emit failed if Device failed to initialized', async () => {
@@ -862,10 +863,7 @@ describe('PreflightTest', () => {
       assert.equal(preflight.status, PreflightTest.Status.Failed);
       sinon.assert.calledOnce(deviceContext.destroy);
       sinon.assert.calledOnce(onFailed);
-      sinon.assert.calledWithExactly(onFailed, {
-        code: 31008,
-        message: 'Call cancelled',
-      });
+      assert.equal((onFailed.args[0][0] as TwilioError).code, 31008);
     });
 
     it(`should emit failed on fatal device errors and destroy device`, async () => {


### PR DESCRIPTION
We had some gaps where we were emitting the old Error format. This brings those up to date. See attached CHANGELOG.md changes for each error code that changed as a result.