### PR TITLE
[VBLOCKS-134] Regional authentication for insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Passing the `rtcConfiguration` parameter to these functions will override any pr
 1.13.1 (Jan 11, 2021)
 =======
 
+New Features
+------------
+
+### Twilio Home Region Support for Insights
+TODO:
+
 Additions
 ---------
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ connect-src https://eventgw.twilio.com https://media.twiliocdn.com https://sdk.t
 connect-src https://eventgw.twilio.com https://media.twiliocdn.com https://sdk.twilio.com wss://chunderw-vpc-gll-us1.twilio.com wss://chunderw-vpc-gll-au1.twilio.com wss://chunderw-vpc-gll.twilio.com
 ```
 
+If you are providing a home region grant into your [Twilio access token](https://www.twilio.com/docs/iam/access-tokens), you need to add the insights endpoint in your `connect-src` directive using `eventgw.{homeRegion}.twilio.com` format. Below is an example if your home region grant is `sg1`.
+
+```
+connect-src https://eventgw.sg1.twilio.com wss://chunderw-vpc-gll.twilio.com https://media.twiliocdn.com https://sdk.twilio.com
+```
+
 License
 -------
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -21,6 +21,7 @@ import {
 import Log from './log';
 import { PreflightTest } from './preflight/preflight';
 import {
+  createEventGatewayURI,
   getChunderURIs,
   getRegionShortcode,
   Region,
@@ -373,7 +374,6 @@ class Device extends EventEmitter {
     debug: false,
     dscp: true,
     enableIceRestart: false,
-    eventgw: 'eventgw.twilio.com',
     forceAggressiveIceNomination: false,
     iceServers: [],
     noRegister: false,
@@ -768,14 +768,19 @@ class Device extends EventEmitter {
       this.soundcache.set(name as Device.SoundName, sound);
     }
 
-    this._publisher = (this.options.Publisher || Publisher)('twilio-js-sdk', token, {
+    const publisherOptions = {
       defaultPayload: this._createDefaultPayload,
-      host: this.options.eventgw,
       metadata: {
         app_name: this.options.appName,
         app_version: this.options.appVersion,
       },
-    } as any);
+    } as any;
+
+    if (this.options.eventgw) {
+      publisherOptions.host = this.options.eventgw;
+    }
+
+    this._publisher = (this.options.Publisher || Publisher)('twilio-js-sdk', token, publisherOptions);
 
     if (this.options.publishEvents === false) {
       this._publisher.disable();
@@ -1117,6 +1122,7 @@ class Device extends EventEmitter {
     const region = getRegionShortcode(payload.region);
     this._edge = regionToEdge[region as Region] || payload.region;
     this._region = region || payload.region;
+    this._publisher.setHost(createEventGatewayURI(payload.home));
     this._sendPresence();
   }
 

--- a/lib/twilio/eventpublisher.js
+++ b/lib/twilio/eventpublisher.js
@@ -32,8 +32,7 @@ function EventPublisher(productName, token, options) {
 
   // Apply default options
   options = Object.assign({
-    defaultPayload() { return { }; },
-    host: 'eventgw.twilio.com'
+    defaultPayload() { return { }; }
   }, options);
 
   let defaultPayload = options.defaultPayload;
@@ -52,7 +51,7 @@ function EventPublisher(productName, token, options) {
       get() { return isEnabled; },
       set(_isEnabled) { isEnabled = _isEnabled; }
     },
-    _host: { value: options.host },
+    _host: { value: options.host, writable: true },
     _request: { value: options.request || request, writable: true },
     _token: { value: token, writable: true },
     isEnabled: {
@@ -88,7 +87,7 @@ util.inherits(EventPublisher, EventEmitter);
  * @returns {Promise} Fulfilled if the HTTP response is 20x.
  */
 EventPublisher.prototype._post = function _post(endpointName, level, group, name, payload, connection, force) {
-  if (!this.isEnabled && !force) {
+  if ((!this.isEnabled && !force) || !this._host) {
     return Promise.resolve();
   }
 
@@ -221,6 +220,14 @@ EventPublisher.prototype.postMetrics = function postMetrics(group, name, metrics
 
     resolve(this._post('EndpointMetrics', 'info', group, name, samples, connection));
   });
+};
+
+/**
+ * Update the host address of the insights server to publish to.
+ * @param {String} host - The new host address of the insights server.
+ */
+EventPublisher.prototype.setHost = function setHost(host) {
+  this._host = host;
 };
 
 /**

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -233,10 +233,17 @@ export const defaultEdge: Edge = Edge.Roaming;
 export const defaultChunderRegionURI: string = 'chunderw-vpc-gll.twilio.com';
 
 /**
+ * The default event gateway URI to publish to.
+ * @constant
+ * @private
+ */
+const defaultEventGatewayURI: string = 'eventgw.twilio.com';
+
+/**
  * String template for a region chunder URI
  * @param region - The region.
  */
-function createChunderRegionUri(region: string): string {
+function createChunderRegionURI(region: string): string {
   return region === defaultRegion
     ? defaultChunderRegionURI
     : `chunderw-vpc-gll-${region}.twilio.com`;
@@ -246,8 +253,14 @@ function createChunderRegionUri(region: string): string {
  * String template for an edge chunder URI
  * @param edge - The edge.
  */
-function createChunderEdgeUri(edge: string): string {
+function createChunderEdgeURI(edge: string): string {
   return `voice-js.${edge}.twilio.com`;
+}
+
+export function createEventGatewayURI(region: string): string {
+  return region
+    ? `eventgw.${region}.twilio.com`
+    : defaultEventGatewayURI;
 }
 
 /**
@@ -312,14 +325,14 @@ export function getChunderURIs(
       );
     }
 
-    uris = [createChunderRegionUri(chunderRegion)];
+    uris = [createChunderRegionURI(chunderRegion)];
   } else if (edge) {
     const edgeValues = Object.values(Edge) as string[];
     const edgeParams = Array.isArray(edge) ? edge : [edge];
 
     uris = edgeParams.map((param: Edge) => edgeValues.includes(param)
-      ? createChunderRegionUri(edgeToRegion[param])
-      : createChunderEdgeUri(param));
+      ? createChunderRegionURI(edgeToRegion[param])
+      : createChunderEdgeURI(param));
   } else {
     uris = [defaultChunderRegionURI];
   }

--- a/tests/eventpublisher.js
+++ b/tests/eventpublisher.js
@@ -8,6 +8,7 @@ describe('EventPublisher', () => {
   before(() => {
     const options = {
       defaultPayload: createDefaultFakePayload,
+      host: 'foo',
       request: fakeRequest,
       metadata: {
         app_name: 'foo',
@@ -26,7 +27,7 @@ describe('EventPublisher', () => {
     it('should set the correct properties', () => {
       assert.equal(publisher._defaultPayload, createDefaultFakePayload);
       assert.equal(publisher._isEnabled, true);
-      assert.equal(publisher._host, 'eventgw.twilio.com');
+      assert.equal(publisher._host, 'foo');
       assert.equal(publisher._request, fakeRequest);
       assert.equal(publisher.isEnabled, true);
       assert.equal(publisher.productName, 'test');
@@ -45,6 +46,7 @@ describe('EventPublisher', () => {
       connection = new FakeConnection();
       mock = { 
         _defaultPayload() { return { }; },
+        _host: 'foo',
         _post: EventPublisher.prototype._post,
         _request: { post: sinon.spy((a, cb) => { cb(); }) },
         token: 'abc123'
@@ -66,6 +68,31 @@ describe('EventPublisher', () => {
       EventPublisher.prototype.post.apply(mock, params).catch(() => {
         sinon.assert.calledWith(mock.emit, 'error', 'foo');
         done()
+      });
+    });
+
+    describe('setHost', () => {
+      beforeEach(() => {
+        mock = {
+          _defaultPayload() { return { }; },
+          _post: EventPublisher.prototype._post,
+          _request: { post: sinon.spy((a, cb) => { cb(); }) },
+          token: 'abc123'
+        };
+      });
+
+      it('should not post a request if host is empty', () => {
+        return EventPublisher.prototype.post.apply(mock, params).then(() => {
+          sinon.assert.notCalled(mock._request.post);
+        });
+      });
+
+      it('should post a request after setting the host', () => {
+        EventPublisher.prototype.setHost.call(mock, 'foo');
+        return EventPublisher.prototype.post.apply(mock, params).then(() => {
+          sinon.assert.calledOnce(mock._request.post);
+          assert.equal(mock._request.post.args[0][0].url, 'https://foo/v4/EndpointEvents');
+        });
       });
     });
 
@@ -121,6 +148,7 @@ describe('EventPublisher', () => {
   ['debug', 'info', 'warn', 'error'].forEach((level, i) => {
     const publisher = new EventPublisher('test', 'token', {
       defaultPayload: createDefaultFakePayload,
+      host: 'foo',
       request: fakeRequest
     });
     const publishLevel = `${level.toUpperCase()}${level === 'warn' ? 'ING' : ''}`

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -320,6 +320,30 @@ describe('Device', function() {
       device.setup(token, Object.assign({ rtcConfiguration }, setupOptions));
     });
 
+    describe('insights gateway', () => {
+      beforeEach(() => {
+        publisher.setHost = sinon.stub();
+      });
+
+      it('should not set host address before signaling is connected', () => {
+        sinon.assert.notCalled(publisher.setHost);
+      });
+
+      it('should set default host address if home is not available', () => {
+        pstream.emit('connected', {});
+        sinon.assert.calledOnce(publisher.setHost);
+        sinon.assert.calledWithExactly(publisher.setHost, 'eventgw.twilio.com');
+      });
+
+      Object.values(Region).forEach(region => {
+        it(`should set host to eventgw.${region}.twilio.com when home is set to ${region}`, () => {
+          pstream.emit('connected', { home: region});
+          sinon.assert.calledOnce(publisher.setHost);
+          sinon.assert.calledWithExactly(publisher.setHost, `eventgw.${region}.twilio.com`);
+        });
+      });
+    });
+
     describe('deprecated handler methods', () => {
       Object.entries(Device.EventName).forEach(([eventName, eventString]) => {
         it(`should set an event listener on Device for .${eventString}(handler)`, () => {

--- a/tests/unit/regions.ts
+++ b/tests/unit/regions.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import {
+  createEventGatewayURI,
   defaultEdge,
   defaultRegion,
   deprecatedRegions,
@@ -13,6 +14,20 @@ import {
 } from '../../lib/twilio/regions';
 
 describe('regions', () => {
+  describe('createEventGatewayURI', () => {
+    [null, '', undefined, 0].forEach((home: any) => {
+      it(`should set event gateway uri to eventgw.twilio.com if home is '${home}'`, () => {
+        assert.equal(createEventGatewayURI(home), 'eventgw.twilio.com');
+      });
+    });
+
+    Object.values(Region).concat(['foo', 'bar'] as any).forEach((home: any) => {
+      it(`should set event gateway uri to eventgw.${home}.twilio.com when home is set to '${home}'`, () => {
+        assert.equal(createEventGatewayURI(home), `eventgw.${home}.twilio.com`);
+      });
+    });
+  });
+
   describe('getChunderURI', () => {
     let onDeprecated: sinon.SinonSpy;
 


### PR DESCRIPTION
* CLIENT-7932 | Regional authentication for insights

* Name URI variable consistently

<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-134](https://issues.corp.twilio.com/browse/VBLOCKS-134)

### Description

This PR updates the Twilio Regional implementation to the 1.14 version of the SDK from the feature branch `regional_authentication` as originally implemented by @charliesantos .

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
