### PR TITLE
Using target PC state if connectionState is not available

### DIFF
--- a/lib/twilio/rtc/peerconnection.js
+++ b/lib/twilio/rtc/peerconnection.js
@@ -711,10 +711,21 @@ PeerConnection.prototype._setupChannel = function() {
   };
 
   // Chrome 72+
-  pc.onconnectionstatechange = () => {
-    this._log.info(`pc.connectionState is "${pc.connectionState}"`);
-    this.onpcconnectionstatechange(pc.connectionState);
-    this._onMediaConnectionStateChange(pc.connectionState);
+  pc.onconnectionstatechange = event => {
+    let state = pc.connectionState;
+    if (!state && event && event.target) {
+      // VDI environment
+      const targetPc = event.target;
+      state = targetPc.connectionState || targetPc.connectionState_;
+      this._log.info(`pc.connectionState not detected. Using target PC. State=${state}`);
+    }
+    if (!state) {
+      this._log.warn(`onconnectionstatechange detected but state is "${state}"`);
+    } else {
+      this._log.info(`pc.connectionState is "${state}"`);
+    }
+    this.onpcconnectionstatechange(state);
+    this._onMediaConnectionStateChange(state);
   };
 
   pc.onicecandidate =  event => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

https://issues.corp.twilio.com/browse/VBLOCKS-1389

### Description

- Connection states are not available on VDI. Using a different mechanism to read them. This fixes insights errors since we are not sending undefined anymore when on VDI

TODO:
Fix call invite errors
Tests (different PR)

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
